### PR TITLE
Enable Go mod support by default for Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+export GO111MODULE=on
+
 REPO=qa.docker.lamoda.ru
 NAME=gonkey
-
 VERSION=$(shell git describe --tags 2> /dev/null || git rev-parse --short HEAD)
 
 DOCKER_TAG ?= latest


### PR DESCRIPTION
By default, Go modules are disabled inside `$GOPATH/src`. `GO111MODULE=on` variable force to use go mod by default.