### PR TITLE
Add multistage docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,17 @@
-FROM alpine:3.6
+FROM golang:1.12 as build
 
+ENV GOOS linux
+ENV GOARCH amd64
+ENV CGO_ENABLED 0
+ENV GO111MODULE on
+
+COPY . /go/src/github.com/lamoda/gonkey
+WORKDIR /go/src/github.com/lamoda/gonkey
+RUN make build
+
+FROM alpine:3.9
 LABEL Author="Denis Sheshnev <denis.sheshnev@lamoda.ru>"
 
-COPY gonkey /bin/gonkey
+COPY --from=build /go/src/github.com/lamoda/gonkey/gonkey /bin/gonkey
 ENTRYPOINT ["/bin/gonkey"]
 CMD ["-spec=/gonkey/swagger.yaml", "-host=${HOST_ARG}"]


### PR DESCRIPTION
Fixes problem with non-working docker images built on systems that differs from linux x86_64 (alpine image arch).