### PR TITLE
Fixtures: Using default keyword at inserting data for non-filled fields

### DIFF
--- a/fixtures/loader.go
+++ b/fixtures/loader.go
@@ -360,7 +360,11 @@ func (f *Loader) buildInsertQuery(ctx *loadContext, t string, rows table) (strin
 	for i, row := range rows {
 		dbValuesRow := make([]string, len(fields))
 		for k, name := range fields {
-			value, _ := row[name]
+			value, present := row[name]
+			if !present {
+				dbValuesRow[k] = "default" // default is a PostgreSQL keyword
+				continue
+			}
 			// resolve references
 			if stringValue, ok := value.(string); ok {
 				if len(stringValue) > 0 && stringValue[0] == '$' {


### PR DESCRIPTION
Previously when you define a few rows of the same table, for example:
```
  table:
    - field1: true
       field_not_null_with_default: true

    - field1: false
       # field_not_null_with_default omitted
```

The loader uses following query for insertion:
```
INSERT INTO table (field1, field_with_default) VALUES
    (true, true),
    (false, NULL); -- <- mistake
```
Which lead to "value violates not null constraint" error.


This pull request fixes this behaviour, so the query will look like:
```
INSERT INTO table (field1, field_with_default) VALUES
    (true, true),
    (false, default);
```

`default` is the keyword for inserting field's default value.