### PR TITLE
#32 Reset mocks for each test

### DIFF
--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -17,8 +17,6 @@ func NewLoader(mocks *Mocks) *Loader {
 }
 
 func (l *Loader) Load(mocksDefinition map[string]interface{}) error {
-	// prevent deriving the definition from previous test
-	l.mocks.ResetDefinitions()
 	for serviceName, definition := range mocksDefinition {
 		service := l.mocks.Service(serviceName)
 		if service == nil {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -97,6 +97,13 @@ func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*mode
 		}
 	}
 
+	// reset mocks
+	if r.config.Mocks != nil {
+		// prevent deriving the definition from previous test
+		r.config.Mocks.ResetDefinitions()
+		r.config.Mocks.ResetRunningContext()
+	}
+
 	// load mocks
 	if r.config.MocksLoader != nil && v.ServiceMocks() != nil {
 		if err := r.config.MocksLoader.Load(v.ServiceMocks()); err != nil {
@@ -104,19 +111,14 @@ func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*mode
 		}
 	}
 
-	//reset mocks
-	if r.config.Mocks != nil {
-		r.config.Mocks.ResetRunningContext()
-	}
-
-	//launch script in cmd interface
+	// launch script in cmd interface
 	if v.BeforeScriptPath() != "" {
 		if err := cmd_runner.CmdRun(v.BeforeScriptPath(), v.BeforeScriptTimeout()); err != nil {
 			return nil, err
 		}
 	}
 
-	//make pause
+	// make pause
 	pause := v.Pause()
 	if pause > 0 {
 		time.Sleep(time.Duration(pause) * time.Second)


### PR DESCRIPTION
Previously `ResetDefinitions()` was called only if test case contained `mocks` directive, which lead to mocks definitions from previous test not being reset. This PR fixes it.
Checked changes on around 170 test cases in our projects.