### PR TITLE
Add variables support

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lamoda/gonkey/output/console_colored"
 	"github.com/lamoda/gonkey/runner"
 	"github.com/lamoda/gonkey/testloader/yaml_file"
+	"github.com/lamoda/gonkey/variables"
 )
 
 func main() {
@@ -74,10 +75,14 @@ func main() {
 		log.Fatal(errors.New("you should specify db_dsn to load fixtures"))
 	}
 
+	// TODO: get variables from .env-file
+	vars := variables.New()
+
 	r := runner.New(
 		&runner.Config{
 			Host:           config.Host,
 			FixturesLoader: fixturesLoader,
+			Variables:      vars,
 		},
 		yaml_file.NewLoader(config.TestsLocation),
 	)

--- a/models/test.go
+++ b/models/test.go
@@ -3,9 +3,11 @@ package models
 // Common Test interface
 type TestInterface interface {
 	ToQuery() string
+	GetRequest() string
 	ToJSON() ([]byte, error)
 	GetMethod() string
 	Path() string
+	GetResponses() map[int]string
 	GetResponse(code int) (string, bool)
 	GetName() string
 	Fixtures() []string
@@ -17,11 +19,23 @@ type TestInterface interface {
 	Headers() map[string]string
 	DbQueryString() string
 	DbResponseJson() []string
+	GetVariables() map[string]string
+
+	// setters
+	SetQuery(string)
+	SetMethod(string)
+	SetPath(string)
+	SetRequest(string)
+	SetResponses(map[int]string)
+	SetHeaders(map[string]string)
 
 	// comparison properties
 	NeedsCheckingValues() bool
 	IgnoreArraysOrdering() bool
 	DisallowExtraFields() bool
+
+	// Clone returns copy of current object
+	Clone() TestInterface
 }
 
 type Summary struct {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lamoda/gonkey/models"
 	"github.com/lamoda/gonkey/output"
 	"github.com/lamoda/gonkey/testloader"
+	"github.com/lamoda/gonkey/variables"
 )
 
 type Config struct {
@@ -20,6 +21,7 @@ type Config struct {
 	FixturesLoader *fixtures.Loader
 	Mocks          *mocks.Mocks
 	MocksLoader    *mocks.Loader
+	Variables      *variables.Variables
 }
 
 type Runner struct {
@@ -94,6 +96,10 @@ func (r *Runner) Run() (*models.Summary, error) {
 }
 
 func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*models.Result, error) {
+
+	r.config.Variables.Load(v.GetVariables())
+	v = r.config.Variables.Apply(v)
+
 	// load fixtures
 	if r.config.FixturesLoader != nil && v.Fixtures() != nil {
 		if err := r.config.FixturesLoader.Load(v.Fixtures()); err != nil {

--- a/testloader/yaml_file/test.go
+++ b/testloader/yaml_file/test.go
@@ -28,8 +28,16 @@ func (t *Test) Path() string {
 	return t.RequestURL
 }
 
+func (t *Test) GetRequest() string {
+	return t.Request
+}
+
 func (t *Test) ToJSON() ([]byte, error) {
 	return []byte(t.Request), nil
+}
+
+func (t *Test) GetResponses() map[int]string {
+	return t.Responses
 }
 
 func (t *Test) GetResponse(code int) (string, bool) {
@@ -87,4 +95,33 @@ func (t *Test) DbQueryString() string {
 
 func (t *Test) DbResponseJson() []string {
 	return t.DbResponse
+}
+
+func (t *Test) GetVariables() map[string]string {
+	return t.Variables
+}
+
+func (t *Test) Clone() models.TestInterface {
+	res := *t
+
+	return &res
+}
+
+func (t *Test) SetQuery(val string) {
+	t.QueryParams = val
+}
+func (t *Test) SetMethod(val string) {
+	t.Method = val
+}
+func (t *Test) SetPath(val string) {
+	t.RequestURL = val
+}
+func (t *Test) SetRequest(val string) {
+	t.Request = val
+}
+func (t *Test) SetResponses(val map[int]string) {
+	t.Responses = val
+}
+func (t *Test) SetHeaders(val map[string]string) {
+	t.HeadersVal = val
 }

--- a/testloader/yaml_file/test_definition.go
+++ b/testloader/yaml_file/test_definition.go
@@ -2,6 +2,7 @@ package yaml_file
 
 type TestDefinition struct {
 	Name               string                 `json:"name" yaml:"name"`
+	Variables          map[string]string      `json:"variables" yaml:"variables"`
 	Method             string                 `json:"method" yaml:"method"`
 	RequestURL         string                 `json:"path" yaml:"path"`
 	QueryParams        string                 `json:"query" yaml:"query"`

--- a/testloader/yaml_file/test_variables_test.go
+++ b/testloader/yaml_file/test_variables_test.go
@@ -1,0 +1,76 @@
+package yaml_file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/lamoda/gonkey/models"
+	"github.com/lamoda/gonkey/variables"
+)
+
+const requestOriginal = `{"reqParam": "{{ $reqParam }}"}`
+const requestApplied = `{"reqParam": "reqParam_value"}`
+
+func TestParseTestsWithVariables(t *testing.T) {
+
+	tests, err := parseTestDefinitionFile("testdata/variables.yaml")
+	if err != nil {
+		t.Error(err)
+	}
+
+	testOriginal := &tests[0]
+
+	vars := variables.New()
+	vars.Load(testOriginal.GetVariables())
+	testApplied := vars.Apply(testOriginal)
+
+	// check that original test is not changed
+	checkOriginal(t, testOriginal)
+
+	checkApplied(t, testApplied)
+}
+
+func checkOriginal(t *testing.T, test models.TestInterface) {
+
+	t.Helper()
+
+	req, err := test.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, requestOriginal, string(req))
+
+	assert.Equal(t, "{{ $method }}", test.GetMethod())
+	assert.Equal(t, "/some/path/{{ $pathPart }}", test.Path())
+	assert.Equal(t, "{{ $query }}", test.ToQuery())
+	assert.Equal(t, map[string]string{"header1": "{{ $header }}"}, test.Headers())
+
+	resp, ok := test.GetResponse(200)
+	assert.True(t, ok)
+	assert.Equal(t, "{{ $resp }}", resp)
+
+	resp, ok = test.GetResponse(404)
+	assert.True(t, ok)
+	assert.Equal(t, "{{ $respRx }}", resp)
+}
+
+func checkApplied(t *testing.T, test models.TestInterface) {
+
+	t.Helper()
+
+	req, err := test.ToJSON()
+	assert.NoError(t, err)
+	assert.Equal(t, requestApplied, string(req))
+
+	assert.Equal(t, "POST", test.GetMethod())
+	assert.Equal(t, "/some/path/part_of_path", test.Path())
+	assert.Equal(t, "query_val", test.ToQuery())
+	assert.Equal(t, map[string]string{"header1": "header_val"}, test.Headers())
+
+	resp, ok := test.GetResponse(200)
+	assert.True(t, ok)
+	assert.Equal(t, "resp_val", resp)
+
+	resp, ok = test.GetResponse(404)
+	assert.True(t, ok)
+	assert.Equal(t, "$matchRegexp(^[0-9.]+$)", resp)
+}

--- a/testloader/yaml_file/testdata/variables.yaml
+++ b/testloader/yaml_file/testdata/variables.yaml
@@ -1,0 +1,19 @@
+- method: "{{ $method }}"
+  path: "/some/path/{{ $pathPart }}"
+  variables:
+    tag: "some_tag"
+    reqParam: "reqParam_value"
+    method: "POST"
+    pathPart: "part_of_path"
+    query: "query_val"
+    header: "header_val"
+    resp: "resp_val"
+    respRx: "$matchRegexp(^[0-9.]+$)"
+    jsonParam: "jsonParam_val"
+  query: "{{ $query }}"
+  headers:
+    header1: "{{ $header }}"
+  request: '{"reqParam": "{{ $reqParam }}"}'
+  response:
+    200: "{{ $resp }}"
+    404: "{{ $respRx }}"

--- a/variables/variable.go
+++ b/variables/variable.go
@@ -1,0 +1,41 @@
+package variables
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type Variable struct {
+	name         string
+	value        string
+	defaultValue string
+	rx           *regexp.Regexp
+}
+
+// NewVariable creates new variable with given name and value
+func NewVariable(name, value string) (*Variable, error) {
+
+	rx, err := regexp.Compile(fmt.Sprintf(`{{\s*\$%s\s*}}`, name))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Variable{
+		name:         name,
+		value:        value,
+		defaultValue: value,
+		rx:           rx,
+	}, nil
+}
+
+// perform replaces variable in str to its value
+// and returns result string
+func (v *Variable) Perform(str string) string {
+
+	res := v.rx.ReplaceAllLiteral(
+		[]byte(str),
+		[]byte(v.value),
+	)
+
+	return string(res)
+}

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -1,0 +1,82 @@
+package variables
+
+import "github.com/lamoda/gonkey/models"
+
+type Variables struct {
+	variables variables
+}
+
+type variables map[string]*Variable
+
+func New() *Variables {
+	return &Variables{
+		variables: make(variables),
+	}
+}
+
+// Load adds new variables and replaces values of existing
+func (vs *Variables) Load(variables map[string]string) error {
+	for n, v := range variables {
+		variable, err := NewVariable(n, v)
+		if err != nil {
+			return err
+		}
+		vs.variables[n] = variable
+	}
+
+	return nil
+}
+
+func (vs *Variables) Apply(t models.TestInterface) models.TestInterface {
+
+	res := t.Clone()
+
+	if vs == nil {
+		return res
+	}
+
+	res.SetQuery(vs.perform(res.ToQuery()))
+	res.SetMethod(vs.perform(res.GetMethod()))
+	res.SetPath(vs.perform(res.Path()))
+	res.SetRequest(vs.perform(res.GetRequest()))
+
+	res.SetResponses(vs.performResponses(res.GetResponses()))
+	res.SetHeaders(vs.performHeaders(res.Headers()))
+
+	return res
+}
+
+// perform replaces all variables in str to their values
+// and returns result string
+func (vs *Variables) perform(str string) string {
+
+	for _, v := range vs.variables {
+		str = v.Perform(str)
+	}
+
+	return str
+}
+
+func (vs *Variables) Len() int {
+	return len(vs.variables)
+}
+
+func (vs *Variables) performHeaders(headers map[string]string) map[string]string {
+
+	res := make(map[string]string)
+
+	for k, v := range headers {
+		res[k] = vs.perform(v)
+	}
+	return res
+}
+
+func (vs *Variables) performResponses(responses map[int]string) map[int]string {
+
+	res := make(map[int]string)
+
+	for k, v := range responses {
+		res[k] = vs.perform(v)
+	}
+	return res
+}


### PR DESCRIPTION
More info: [issue](https://github.com/lamoda/gonkey/issues/43) (in Russian)
Now it's possible to use variables in test cases, i.e.:

```
  - name: "some_test"
    variables:
      var1: "value1"
      var2: "value2"
    path: /some/path/{{ $var1 }}
    response:
        200: "{{ $var2 }}"
```

Variables is available in next parameters: _query, method, path, request, response, headers_

The next step is to be able to load variables from env-file