### PR TITLE
add possibility to set vars from response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tmpfile*
 # debug
 debug
 **/debug.test
+
+# local env-file
+.*.env

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	github.com/stretchr/testify v1.5.1
+	github.com/tidwall/gjson v1.6.0
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/go-openapi/jsonreference v0.17.0 h1:yJW3HCkTHg7NOA+gZ83IPHzUSnUzGXhGm
 github.com/go-openapi/jsonreference v0.17.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.18.0/go.mod h1:g4xxGn04lDIRh0GJb5QlpE3HfopLOL6uZrK/VgnsK9I=
 github.com/go-openapi/jsonreference v0.19.2/go.mod h1:jMjeRr2HHw6nAVajTXJ4eiUwohSTlpa0o73RUL1owJc=
+github.com/go-openapi/jsonreference v0.19.3 h1:5cxNfTy0UVC3X8JL5ymxzyoUZmo8iZb+jeTWn7tUa8o=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/loads v0.17.0/go.mod h1:72tmFy5wsWx89uEVddd0RjRWPZm92WRLhf7AC+0+OOU=
 github.com/go-openapi/loads v0.18.0 h1:2A3goxrC4KuN8ZrMKHCqAAugtq6A6WfXVfOIKUbZ4n0=
@@ -58,6 +59,7 @@ github.com/go-openapi/loads v0.19.5/go.mod h1:dswLCAdonkRufe/gSUC3gN8nTSaB9uaS2e
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9 h1:zXd+rkzHwMIYVTJ/j/v8zUQ9j3Ir32gC5Dn9DzZVvCk=
 github.com/go-openapi/runtime v0.0.0-20180920151709-4f900dc2ade9/go.mod h1:6v9a6LTXWQCdL8k1AO3cvqx5OtZY/Y9wKTgaoP6YRfA=
 github.com/go-openapi/runtime v0.19.0/go.mod h1:OwNfisksmmaZse4+gpV3Ne9AyMOlP1lt4sK4FXt0O64=
+github.com/go-openapi/runtime v0.19.4 h1:csnOgcgAiuGoM/Po7PEpKDoNulCcF3FGbSnbHfxgjMI=
 github.com/go-openapi/runtime v0.19.4/go.mod h1:X277bwSUBxVlCYR3r7xgZZGKVvBd/29gLDlFGtJ8NL4=
 github.com/go-openapi/spec v0.17.0/go.mod h1:XkF/MOi14NmjsfZ8VtAKf8pIlbZzyoTvZsdfssdxcBI=
 github.com/go-openapi/spec v0.18.0 h1:aIjeyG5mo5/FrvDkpKKEGZPmF9MPHahS72mzfVqeQXQ=
@@ -147,6 +149,7 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.0/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
+github.com/mailru/easyjson v0.7.1 h1:mdxE1MF9o53iCb2Ghj1VfWvh7ZOwHpnVG/xwXrV90U8=
 github.com/mailru/easyjson v0.7.1/go.mod h1:KAzv3t3aY1NaHWoQz1+4F1ccyAH66Jk7yos7ldAVICs=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
@@ -182,7 +185,12 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/tidwall/gjson v1.6.0 h1:9VEQWz6LLMUsUl6PueE49ir4Ka6CzLymOAZDxpFsTDc=
+github.com/tidwall/gjson v1.6.0/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
+github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
+github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=

--- a/main.go
+++ b/main.go
@@ -84,13 +84,11 @@ func main() {
 		log.Println(errors.New("error loading .env file"), err)
 	}
 
-	vars := variables.New()
-
 	r := runner.New(
 		&runner.Config{
 			Host:           config.Host,
 			FixturesLoader: fixturesLoader,
-			Variables:      vars,
+			Variables:      variables.New(),
 		},
 		yaml_file.NewLoader(config.TestsLocation),
 	)

--- a/models/test.go
+++ b/models/test.go
@@ -21,6 +21,7 @@ type TestInterface interface {
 	DbQueryString() string
 	DbResponseJson() []string
 	GetVariables() map[string]string
+	GetVariablesToSet() map[int]map[string]string
 
 	// setters
 	SetQuery(string)

--- a/runner/previous_result_test.go
+++ b/runner/previous_result_test.go
@@ -1,0 +1,58 @@
+package runner
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	testDir = "testdata"
+	body    = "bla"
+)
+
+func Test_PreviousResult(t *testing.T) {
+
+	srv := testServer()
+	defer srv.Close()
+
+	RunWithTesting(t, &RunWithTestingParams{
+		Server:   srv,
+		TestsDir: testDir,
+	})
+}
+
+func testServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		resp := []byte(body)
+
+		type nestedInfo struct {
+			NestedField1 string `json:"nested_field_1"`
+			NestedField2 string `json:"nested_field_2"`
+		}
+
+		if r.URL.Path == "/some/path/json" {
+			w.Header().Set("Content-Type", "application/json")
+
+			resp, _ = json.Marshal(&struct {
+				Status      string     `json:"status"`
+				Other       string     `json:"other"`
+				UnusedField string     `json:"unused_field"`
+				NestedInfo  nestedInfo `json:"nested_info"`
+			}{
+				Status:      "status_val",
+				Other:       "some_info",
+				UnusedField: "useless_info",
+				NestedInfo: nestedInfo{
+					NestedField1: "nested_val1",
+					NestedField2: "nested_val2",
+				},
+			})
+		}
+
+		_, _ = w.Write(resp)
+
+	}))
+}

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -14,6 +14,7 @@ import (
 	"github.com/lamoda/gonkey/output/allure_report"
 	testingOutput "github.com/lamoda/gonkey/output/testing"
 	"github.com/lamoda/gonkey/testloader/yaml_file"
+	"github.com/lamoda/gonkey/variables"
 )
 
 type RunWithTestingParams struct {
@@ -52,6 +53,7 @@ func RunWithTesting(t *testing.T, params *RunWithTestingParams) {
 			Mocks:          params.Mocks,
 			MocksLoader:    mocksLoader,
 			FixturesLoader: fixturesLoader,
+			Variables:      variables.New(),
 		},
 		yamlLoader,
 	)

--- a/runner/testdata/previous-result.yaml
+++ b/runner/testdata/previous-result.yaml
@@ -1,0 +1,42 @@
+- method: "GET"
+  path: "/some/path/plain_text"
+  response:
+    200: "bla"
+  variables_to_set:
+    200: "myResp"
+- method: "GET"
+  path: "/some/path/plain_text"
+  response:
+    200: "{{$myResp}}"
+
+- method: "GET"
+  path: "/some/path/json"
+  response:
+    200: >
+      {
+        "status": "status_val",
+        "other": "some_info",
+        "unused_field": "useless_info",
+        "nested_info": {
+          "nested_field_1": "nested_val1",
+          "nested_field_2": "nested_val2"
+        }
+      }
+  variables_to_set:
+    200:
+      statusVar: "status"
+      someField: "other"
+      nestedVar1: "nested_info.nested_field_1"
+      nestedVar2: "nested_info.nested_field_2"
+- method: "GET"
+  path: "/some/path/json"
+  response:
+    200: >
+      {
+        "status": "{{$statusVar}}",
+        "other": "{{$someField}}",
+        "nested_info": {
+                "nested_field_1": "{{$nestedVar1}}",
+                "nested_field_2": "{{$nestedVar2}}"
+         }
+      }

--- a/testloader/yaml_file/test.go
+++ b/testloader/yaml_file/test.go
@@ -107,6 +107,10 @@ func (t *Test) GetVariables() map[string]string {
 	return t.Variables
 }
 
+func (t *Test) GetVariablesToSet() map[int]map[string]string {
+	return t.VariablesToSet
+}
+
 func (t *Test) Clone() models.TestInterface {
 	res := *t
 

--- a/testloader/yaml_file/test_definition.go
+++ b/testloader/yaml_file/test_definition.go
@@ -3,6 +3,7 @@ package yaml_file
 type TestDefinition struct {
 	Name               string                    `json:"name" yaml:"name"`
 	Variables          map[string]string         `json:"variables" yaml:"variables"`
+	VariablesToSet     VariablesToSet            `json:"variables_to_set" yaml:"variables_to_set"`
 	Method             string                    `json:"method" yaml:"method"`
 	RequestURL         string                    `json:"path" yaml:"path"`
 	QueryParams        string                    `json:"query" yaml:"query"`
@@ -39,4 +40,52 @@ type comparisonParams struct {
 type beforeScriptParams struct {
 	PathTmpl string `json:"path" yaml:"path"`
 	Timeout  int    `json:"timeout" yaml:"timeout"`
+}
+
+type VariablesToSet map[int]map[string]string
+
+/*
+There can be two types of data in yaml-file:
+1) JSON-paths:
+	VariablesToSet:
+		<code1>:
+			<varName1>: <JSON_Path1>
+			<varName2>: <JSON_Path2>
+2) Plain text:
+	 VariablesToSet:
+		<code1>: <varName1>
+		<code2>: <varName2>
+		...
+   In this case we unmarshall values to format similar to JSON-paths format with empty paths:
+	 VariablesToSet:
+		<code1>:
+			<varName1>: ""
+		<code2>:
+			<varName2>: ""
+*/
+func (v *VariablesToSet) UnmarshalYAML(unmarshal func(interface{}) error) error {
+
+	res := make(map[int]map[string]string)
+
+	// try to unmarshall as plaint text
+	var plain map[int]string
+	if err := unmarshal(&plain); err == nil {
+
+		for code, varName := range plain {
+			res[code] = map[string]string{
+				varName: "",
+			}
+		}
+
+		*v = res
+		return nil
+	}
+
+	// json-paths
+	if err := unmarshal(&res); err != nil {
+		return err
+	}
+
+	*v = res
+	return nil
 }

--- a/testloader/yaml_file/test_variables_test.go
+++ b/testloader/yaml_file/test_variables_test.go
@@ -44,7 +44,7 @@ func TestParseTestsWithVariables(t *testing.T) {
 	testOriginal := &tests[0]
 
 	vars := variables.New()
-	err = vars.Load(testOriginal.GetVariables())
+	vars.Load(testOriginal.GetVariables())
 	assert.NoError(t, err)
 
 	testApplied := vars.Apply(testOriginal)

--- a/variables/response_parser.go
+++ b/variables/response_parser.go
@@ -1,0 +1,73 @@
+package variables
+
+import (
+	"fmt"
+
+	"github.com/tidwall/gjson"
+)
+
+func FromResponse(varsToSet map[string]string, body string, isJson bool) (vars *Variables, err error) {
+
+	names, paths := split(varsToSet)
+
+	switch {
+	case isJson:
+		vars, err = fromJson(names, paths, body)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		vars, err = fromPlainText(names, body)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return vars, nil
+
+}
+
+func fromJson(names, paths []string, body string) (*Variables, error) {
+
+	vars := New()
+
+	results := gjson.GetMany(body, paths...)
+
+	for n, res := range results {
+		if !res.Exists() {
+			return nil,
+				fmt.Errorf("path '%s' doesn't exist in given json", paths[n])
+		}
+
+		vars.Add(NewVariable(names[n], res.String()))
+	}
+
+	return vars, nil
+}
+
+func fromPlainText(names []string, body string) (*Variables, error) {
+
+	if len(names) != 1 {
+		return nil,
+			fmt.Errorf(
+				"count of variables for plain-text response should be 1, %d given",
+				len(names),
+			)
+	}
+
+	return New().Add(NewVariable(names[0], body)), nil
+}
+
+// split returns keys and values of given map as separate slices
+func split(m map[string]string) ([]string, []string) {
+
+	values := make([]string, 0, len(m))
+	keys := make([]string, 0, len(m))
+
+	for k, v := range m {
+		keys = append(keys, k)
+		values = append(values, v)
+	}
+
+	return keys, values
+}

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -21,14 +21,19 @@ func New() *Variables {
 }
 
 // Load adds new variables and replaces values of existing
-func (vs *Variables) Load(variables map[string]string) error {
+func (vs *Variables) Load(variables map[string]string) {
 	for n, v := range variables {
 		variable := NewVariable(n, v)
 
 		vs.variables[n] = variable
 	}
+}
 
-	return nil
+// Load adds new variables and replaces values of existing
+func (vs *Variables) Set(name, value string) {
+	v := NewVariable(name, value)
+
+	vs.variables[name] = v
 }
 
 func (vs *Variables) Apply(t models.TestInterface) models.TestInterface {
@@ -48,6 +53,13 @@ func (vs *Variables) Apply(t models.TestInterface) models.TestInterface {
 	newTest.SetHeaders(vs.performHeaders(newTest.Headers()))
 
 	return newTest
+}
+
+// Merge adds given variables to set or overrides existed
+func (vs *Variables) Merge(vars *Variables) {
+	for k, v := range vars.variables {
+		vs.variables[k] = v
+	}
 }
 
 func (vs *Variables) Len() int {
@@ -106,4 +118,10 @@ func (vs *Variables) performResponses(responses map[int]string) map[int]string {
 		res[k] = vs.perform(v)
 	}
 	return res
+}
+
+func (vs *Variables) Add(v *Variable) *Variables {
+	vs.variables[v.name] = v
+
+	return vs
 }


### PR DESCRIPTION
More info: [issue](https://github.com/lamoda/gonkey/issues/43) (in Russian)
Now we can set variables using results of request.

Example:
```
    # if response contains plain text
    - name: "get_last_post_id"
      ...
      variables_to_set:
              200: id

    # if response contains JSON
    - name: "get_last_post_info"
      variables_to_set:
              200:
                id: id
                title: title
```