### PR TITLE
Add upload files support

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -296,6 +296,31 @@ password=private_password
 
 env-файл, например, удобно использовать, когда нужно вынести из теста приватную информацию (пароли, ключи и т.п.)
 
+
+### Загрузка файлов
+
+В тестовом запросе можно загружать файлы. Для этого нужно указать тип запроса - POST и заголовок:
+
+> Content-Type: multipart/form-data
+
+Пример:
+
+```yaml
+ - name: "upload-files"
+   method: POST
+   form:
+       files:
+         file1: "testdata/upload-files/file1.txt"
+         file2: "testdata/upload-files/file2.log"
+   headers:
+     Content-Type: multipart/form-data # case-sensitive, can be omitted
+   response:
+     200: |
+       {
+         "status": "OK"
+       }
+```
+
 ### Фикстуры
 
 Чтобы наполнить базу перед тестом, используются файлы с фикстурами.

--- a/README.md
+++ b/README.md
@@ -296,6 +296,30 @@ password=private_password
 
 env-file can be convenient to hide sensitive information from a test (passwords, keys, etc.)
 
+### Files uploading
+
+You can upload files in test request. For this you must specify the type of request - POST and header:
+
+> Content-Type: multipart/form-data
+
+Example:
+
+```yaml
+ - name: "upload-files"
+   method: POST
+   form:
+       files:
+         file1: "testdata/upload-files/file1.txt"
+         file2: "testdata/upload-files/file2.log"
+   headers:
+     Content-Type: multipart/form-data # case-sensitive, can be omitted
+   response:
+     200: |
+       {
+         "status": "OK"
+       }
+```
+
 ### Fixtures
 
 To seed the DB before the test, gonkey uses fixture files.

--- a/models/test.go
+++ b/models/test.go
@@ -18,6 +18,8 @@ type TestInterface interface {
 	BeforeScriptTimeout() int
 	Cookies() map[string]string
 	Headers() map[string]string
+	ContentType() string
+	GetForm() *Form
 	DbQueryString() string
 	DbResponseJson() []string
 	GetVariables() map[string]string
@@ -28,6 +30,7 @@ type TestInterface interface {
 	SetMethod(string)
 	SetPath(string)
 	SetRequest(string)
+	SetForm(form *Form)
 	SetResponses(map[int]string)
 	SetHeaders(map[string]string)
 
@@ -38,6 +41,11 @@ type TestInterface interface {
 
 	// Clone returns copy of current object
 	Clone() TestInterface
+}
+
+// TODO: add support for form fields
+type Form struct {
+	Files map[string]string `json:"files" yaml:"files"`
 }
 
 type Summary struct {

--- a/runner/request.go
+++ b/runner/request.go
@@ -3,10 +3,14 @@ package runner
 import (
 	"bytes"
 	"crypto/tls"
+	"fmt"
+	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/lamoda/gonkey/models"
@@ -32,31 +36,151 @@ func newClient() (*http.Client, error) {
 	}, nil
 }
 
-func newRequest(host string, test models.TestInterface) (*http.Request, error) {
+func newRequest(host string, test models.TestInterface) (req *http.Request, err error) {
+
+	if test.GetForm() != nil {
+		req, err = newMultipartRequest(host, test)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		req, err = newCommonRequest(host, test)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	for k, v := range test.Cookies() {
+		req.AddCookie(&http.Cookie{Name: k, Value: v})
+	}
+
+	return req, nil
+}
+
+func newMultipartRequest(host string, test models.TestInterface) (*http.Request, error) {
+
+	if test.ContentType() != "" && test.ContentType() != "multipart/form-data" {
+		return nil, fmt.Errorf(
+			"test has unexpected Content-Type: %s, expected: multipart/form-data",
+			test.ContentType(),
+		)
+	}
+
+	var b bytes.Buffer
+	w := multipart.NewWriter(&b)
+
+	params, err := url.ParseQuery(test.GetRequest())
+	if err != nil {
+		return nil, err
+	}
+
+	err = addFields(params, w)
+	if err != nil {
+		return nil, err
+	}
+
+	err = addFiles(test.GetForm().Files, w)
+	if err != nil {
+		return nil, err
+	}
+
+	_ = w.Close()
+
+	req, err := request(test, &b, host)
+	if err != nil {
+		return nil, err
+	}
+
+	// this is necessary, it will contain boundary
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	return req, nil
+
+}
+
+func addFiles(files map[string]string, w *multipart.Writer) error {
+	for name, path := range files {
+
+		err := addFile(path, w, name)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	return nil
+}
+
+func addFile(path string, w *multipart.Writer, name string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	fw, err := w.CreateFormFile(name, filepath.Base(f.Name()))
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(fw, f); err != nil {
+		return err
+	}
+	return nil
+}
+
+func addFields(params url.Values, w *multipart.Writer) error {
+	for k, vv := range params {
+		for _, v := range vv {
+			fw, err := w.CreateFormField(k)
+			if err != nil {
+				return err
+			}
+
+			_, err = fw.Write([]byte(v))
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func newCommonRequest(host string, test models.TestInterface) (*http.Request, error) {
+
 	body, err := test.ToJSON()
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequest(
+
+	req, err := request(test, bytes.NewBuffer(body), host)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	return req, nil
+}
+
+func request(test models.TestInterface, b *bytes.Buffer, host string) (*http.Request, error) {
+
+	req, err := http.NewRequest(
 		strings.ToUpper(test.GetMethod()),
 		host+test.Path()+test.ToQuery(),
-		bytes.NewBuffer(body),
+		b,
 	)
 	if err != nil {
 		return nil, err
 	}
+
 	for k, v := range test.Headers() {
-		request.Header.Add(k, v)
+		req.Header.Add(k, v)
 	}
-	for k, v := range test.Cookies() {
-		request.AddCookie(&http.Cookie{Name: k, Value: v})
-	}
-
-	if request.Header.Get("Content-Type") == "" {
-		request.Header.Set("Content-Type", "application/json")
-	}
-
-	return request, nil
+	return req, nil
 }
 
 func actualRequestBody(req *http.Request) string {

--- a/runner/runner_upload_file_test.go
+++ b/runner/runner_upload_file_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUploadFiles(t *testing.T) {
+	srv := testServerUpload(t)
+	defer srv.Close()
+
+	// TODO: refactor RunWithTesting() for testing negative scenario (when tests has expected errors)
+	RunWithTesting(t, &RunWithTestingParams{
+		Server:   srv,
+		TestsDir: filepath.Join("testdata", "upload-files"),
+	})
+}
+
+type response struct {
+	Status       string `json:"status"`
+	File1Name    string `json:"file_1_name"`
+	File1Content string `json:"file_1_content"`
+	File2Name    string `json:"file_2_name"`
+	File2Content string `json:"file_2_content"`
+}
+
+func testServerUpload(t *testing.T) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		resp := response{
+			Status: "OK",
+		}
+
+		resp.File1Name, resp.File1Content = formFile(t, r, "file1")
+		resp.File2Name, resp.File2Content = formFile(t, r, "file2")
+
+		respData, err := json.Marshal(resp)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+
+		_, err = w.Write(respData)
+		require.NoError(t, err)
+
+		return
+	}))
+}
+
+func formFile(t *testing.T, r *http.Request, field string) (string, string) {
+
+	file, header, err := r.FormFile(field)
+	require.NoError(t, err)
+
+	defer func() { _ = file.Close() }()
+
+	contents, err := ioutil.ReadAll(file)
+	require.NoError(t, err)
+
+	return header.Filename, string(contents)
+}

--- a/runner/testdata/upload-files/file1.txt
+++ b/runner/testdata/upload-files/file1.txt
@@ -1,0 +1,1 @@
+file1_some_text

--- a/runner/testdata/upload-files/file2.log
+++ b/runner/testdata/upload-files/file2.log
@@ -1,0 +1,1 @@
+file2_content

--- a/runner/testdata/upload-files/upload-files.yaml
+++ b/runner/testdata/upload-files/upload-files.yaml
@@ -1,0 +1,35 @@
+- name: "upload-files: with correct Content-Type"
+  method: POST
+  form:
+    files:
+      file1: "testdata/upload-files/file1.txt"
+      file2: "testdata/upload-files/file2.log"
+  headers:
+    Content-Type: multipart/form-data
+  response:
+    200: |
+      {
+        "status": "OK",
+        "file_1_name": "file1.txt",
+        "file_1_content": "file1_some_text",
+        "file_2_name": "file2.log",
+        "file_2_content": "file2_content"
+      }
+
+- name: "upload-files: with empty Content-Type"
+  method: POST
+  form:
+    files:
+      file1: "testdata/upload-files/file1.txt"
+      file2: "testdata/upload-files/file2.log"
+  response:
+    200: |
+      {
+        "status": "OK",
+        "file_1_name": "file1.txt",
+        "file_1_content": "file1_some_text",
+        "file_2_name": "file2.log",
+        "file_2_content": "file2_content"
+      }
+
+# TODO: test with incorrect Content-Type

--- a/testloader/yaml_file/test.go
+++ b/testloader/yaml_file/test.go
@@ -95,6 +95,12 @@ func (t *Test) Headers() map[string]string {
 	return t.HeadersVal
 }
 
+// TODO: it might make sense to do support of case-insensitive checking
+func (t *Test) ContentType() string {
+	ct, _ := t.HeadersVal["Content-Type"]
+	return ct
+}
+
 func (t *Test) DbQueryString() string {
 	return t.DbQuery
 }
@@ -105,6 +111,10 @@ func (t *Test) DbResponseJson() []string {
 
 func (t *Test) GetVariables() map[string]string {
 	return t.Variables
+}
+
+func (t *Test) GetForm() *models.Form {
+	return t.Form
 }
 
 func (t *Test) GetVariablesToSet() map[int]map[string]string {
@@ -126,12 +136,19 @@ func (t *Test) SetMethod(val string) {
 func (t *Test) SetPath(val string) {
 	t.RequestURL = val
 }
+
 func (t *Test) SetRequest(val string) {
 	t.Request = val
 }
+
+func (t *Test) SetForm(val *models.Form) {
+	t.Form = val
+}
+
 func (t *Test) SetResponses(val map[int]string) {
 	t.Responses = val
 }
+
 func (t *Test) SetHeaders(val map[string]string) {
 	t.HeadersVal = val
 }

--- a/testloader/yaml_file/test_definition.go
+++ b/testloader/yaml_file/test_definition.go
@@ -1,9 +1,12 @@
 package yaml_file
 
+import "github.com/lamoda/gonkey/models"
+
 type TestDefinition struct {
 	Name               string                    `json:"name" yaml:"name"`
 	Variables          map[string]string         `json:"variables" yaml:"variables"`
 	VariablesToSet     VariablesToSet            `json:"variables_to_set" yaml:"variables_to_set"`
+	Form               *models.Form              `json:"form" yaml:"form"`
 	Method             string                    `json:"method" yaml:"method"`
 	RequestURL         string                    `json:"path" yaml:"path"`
 	QueryParams        string                    `json:"query" yaml:"query"`

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -52,6 +52,10 @@ func (vs *Variables) Apply(t models.TestInterface) models.TestInterface {
 	newTest.SetResponses(vs.performResponses(newTest.GetResponses()))
 	newTest.SetHeaders(vs.performHeaders(newTest.Headers()))
 
+	if form := newTest.GetForm(); form != nil {
+		newTest.SetForm(vs.performForm(form))
+	}
+
 	return newTest
 }
 
@@ -98,6 +102,16 @@ func (vs *Variables) get(name string) *Variable {
 	}
 
 	return v
+}
+
+func (vs *Variables) performForm(form *models.Form) *models.Form {
+
+	files := make(map[string]string, len(form.Files))
+
+	for k, v := range form.Files {
+		files[k] = vs.perform(v)
+	}
+	return &models.Form{Files: files}
 }
 
 func (vs *Variables) performHeaders(headers map[string]string) map[string]string {


### PR DESCRIPTION
To upload file with test request you must specify the type of request - POST and header:

> Content-Type: multipart/form-data

Example:

```yaml
- name: "upload-files"
  method: POST
  files:
    file1: "testdata/upload-files/file1.txt"
    file2: "testdata/upload-files/file2.log"
  request: "text_field1=text1&text_field2=text2&text_field2=text22"
  headers:
    Content-Type: multipart/form-data
  response:
    200: |
      {
        "status": "OK"
      }

```