### PR TITLE
load env file in runner_testing

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,9 +79,10 @@ func main() {
 		log.Fatal(errors.New("you should specify db_dsn to load fixtures"))
 	}
 
-	err := godotenv.Load(config.EnvFile)
-	if err != nil && config.EnvFile != "" {
-		log.Println(errors.New("error loading .env file"), err)
+	if config.EnvFile != "" {
+		if err := godotenv.Load(config.EnvFile); err != nil {
+			log.Println(errors.New("can't load .env file"), err)
+		}
 	}
 
 	r := runner.New(

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/joho/godotenv"
+
 	"github.com/lamoda/gonkey/checker/response_body"
 	"github.com/lamoda/gonkey/checker/response_db"
 	"github.com/lamoda/gonkey/checker/response_header"
@@ -23,6 +25,7 @@ type RunWithTestingParams struct {
 	Mocks       *mocks.Mocks
 	FixturesDir string
 	DB          *sql.DB
+	EnvFilePath string
 }
 
 // RunWithTesting is a helper function the wraps the common Run and provides simple way
@@ -31,6 +34,12 @@ func RunWithTesting(t *testing.T, params *RunWithTestingParams) {
 	var mocksLoader *mocks.Loader
 	if params.Mocks != nil {
 		mocksLoader = mocks.NewLoader(params.Mocks)
+	}
+
+	if params.EnvFilePath != "" {
+		if err := godotenv.Load(params.EnvFilePath); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	debug := os.Getenv("GONKEY_DEBUG") != ""


### PR DESCRIPTION
When we use Gonkey as a library, we may also want to use env-file.

Also here is little cleanup of env-file loading in main.go