### PR TITLE
Add mysql support in fixtures

### DIFF
--- a/fixtures/loader.go
+++ b/fixtures/loader.go
@@ -2,503 +2,60 @@ package fixtures
 
 import (
 	"database/sql"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"regexp"
-	"sort"
-	"strconv"
 	"strings"
 
 	_ "github.com/lib/pq"
-	"gopkg.in/yaml.v2"
+
+	"github.com/lamoda/gonkey/fixtures/postgres"
 )
 
-const tempTableSuffix = "_table_gonkey"
+type DbType int
 
-type row map[string]interface{}
+const (
+	_ = iota
+	Postgres
+)
 
-type table []row
-
-type rowsDict map[string]row
-
-type fixture struct {
-	Version   string
-	Inherits  []string
-	Tables    yaml.MapSlice
-	Templates yaml.MapSlice
-}
-
-type loadedTable struct {
-	Name string
-	Rows table
-}
-
-type loadContext struct {
-	files          []string
-	tables         []loadedTable
-	refsDefinition rowsDict
-	refsInserted   rowsDict
-}
+const (
+	PostgresParam = "postgres"
+)
 
 type Config struct {
 	DB       *sql.DB
+	DbType   DbType
 	Location string
 	Debug    bool
 }
 
-type Loader struct {
-	db       *sql.DB
-	location string
-	debug    bool
+type Loader interface {
+	Load(names []string) error
 }
 
-func NewLoader(config *Config) *Loader {
-	return &Loader{
-		db:       config.DB,
-		location: strings.TrimRight(config.Location, "/"),
-		debug:    config.Debug,
+func NewLoader(cfg *Config) Loader {
+
+	var loader Loader
+
+	location := strings.TrimRight(cfg.Location, "/")
+
+	switch cfg.DbType {
+	case Postgres:
+		loader = postgres.New(
+			cfg.DB,
+			location,
+			cfg.Debug,
+		)
+	default:
+		panic("unknown db type")
 	}
+
+	return loader
 }
 
-func (f *Loader) Load(names []string) error {
-	ctx := loadContext{
-		refsDefinition: make(rowsDict),
-		refsInserted:   make(rowsDict),
+func FetchDbType(dbType string) DbType {
+	switch dbType {
+	case PostgresParam:
+		return Postgres
+	default:
+		panic("unknown db type param")
 	}
-	// gather data from files
-	for _, name := range names {
-		err := f.loadFile(name, &ctx)
-		if err != nil {
-			return fmt.Errorf("unable to load fixture %s: %s", name, err.Error())
-		}
-	}
-	return f.loadTables(&ctx)
-}
-
-func (f *Loader) loadFile(name string, ctx *loadContext) error {
-	candidates := []string{
-		f.location + "/" + name,
-		f.location + "/" + name + ".yml",
-		f.location + "/" + name + ".yaml",
-	}
-	var err error
-	var file string
-	for _, candidate := range candidates {
-		if _, err = os.Stat(candidate); err == nil {
-			file = candidate
-			break
-		}
-	}
-	if err != nil {
-		return err
-	}
-	// skip previously loaded files
-	if inArray(file, &(*ctx).files) {
-		return nil
-	}
-	if f.debug {
-		fmt.Println("Loading", file)
-	}
-	data, err := ioutil.ReadFile(file)
-	if err != nil {
-		return err
-	}
-	(*ctx).files = append((*ctx).files, file)
-	return f.loadYml(data, ctx)
-}
-
-func (f *Loader) loadYml(data []byte, ctx *loadContext) error {
-	// read yml into struct
-	var loadedFixture fixture
-	if err := yaml.Unmarshal(data, &loadedFixture); err != nil {
-		return err
-	}
-
-	// load inherits
-	for _, inheritFile := range loadedFixture.Inherits {
-		if err := f.loadFile(inheritFile, ctx); err != nil {
-			return err
-		}
-	}
-
-	// loadedFixture.Templates
-	// yaml.MapSlice{
-	//    string => yaml.MapSlice{
-	//        string => interface{}
-	//    }
-	// }
-	for _, template := range loadedFixture.Templates {
-		name := template.Key.(string)
-		if _, ok := ctx.refsDefinition[name]; ok {
-			return fmt.Errorf("unable to load template %s: duplicating ref name", name)
-		}
-		fields := template.Value.(yaml.MapSlice)
-		row := make(row, len(fields))
-		for _, field := range fields {
-			key := field.Key.(string)
-			value, _ := field.Value.(interface{})
-			row[key] = value
-		}
-		if base, ok := row["$extend"]; ok {
-			base := base.(string)
-			baseRow, err := f.resolveReference(ctx.refsDefinition, base)
-			if err != nil {
-				return err
-			}
-			for k, v := range row {
-				baseRow[k] = v
-			}
-			row = baseRow
-		}
-		ctx.refsDefinition[name] = row
-		if f.debug {
-			rowJson, _ := json.Marshal(row)
-			fmt.Printf("Populating ref %s as %s from template\n", name, string(rowJson))
-		}
-	}
-
-	// loadedFixture.Tables
-	// yaml.MapSlice{
-	//    string => []interface{
-	//        yaml.MapSlice{
-	//            string => interface{}
-	//        }
-	//    }
-	// }
-	for _, sourceTable := range loadedFixture.Tables {
-		sourceRows, ok := sourceTable.Value.([]interface{})
-		if !ok {
-			return errors.New("expected array at root level")
-		}
-		rows := make(table, len(sourceRows))
-		for i := range sourceRows {
-			sourceFields := sourceRows[i].(yaml.MapSlice)
-			fields := make(row, len(sourceFields))
-			for j := range sourceFields {
-				fields[sourceFields[j].Key.(string)] = sourceFields[j].Value
-			}
-			rows[i] = fields
-		}
-		lt := loadedTable{
-			Name: sourceTable.Key.(string),
-			Rows: rows,
-		}
-		(*ctx).tables = append((*ctx).tables, lt)
-	}
-	return nil
-}
-
-func (f *Loader) loadTables(ctx *loadContext) error {
-	tx, err := f.db.Begin()
-	if err != nil {
-		return err
-	}
-	defer func() { _ = tx.Rollback() }()
-
-	// truncate first
-	truncatedTables := make(map[string]bool)
-	for _, lt := range ctx.tables {
-		if _, ok := truncatedTables[lt.Name]; ok {
-			// already truncated
-			continue
-		}
-		if err := f.truncateTable(tx, lt.Name); err != nil {
-			return err
-		}
-		truncatedTables[lt.Name] = true
-	}
-	// then load data
-	for _, lt := range ctx.tables {
-		if len(lt.Rows) == 0 {
-			continue
-		}
-		if err := f.loadTable(tx, ctx, lt.Name, lt.Rows); err != nil {
-			return err
-		}
-	}
-	// alter the sequences so they contain max id + 1
-	if err := f.fixSequences(tx); err != nil {
-		return err
-	}
-
-	_ = tx.Commit()
-	return nil
-}
-
-// truncateTable truncates table
-func (f *Loader) truncateTable(tx *sql.Tx, name string) error {
-	query := fmt.Sprintf("TRUNCATE TABLE \"%s\" CASCADE", name)
-	if f.debug {
-		fmt.Println("Issuing SQL:", query)
-	}
-	_, err := tx.Exec(query)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (f *Loader) loadTable(tx *sql.Tx, ctx *loadContext, t string, rows table) error {
-	// $extend keyword allows to import values from a named row
-	for i, row := range rows {
-		if base, ok := row["$extend"]; ok {
-			base := base.(string)
-			baseRow, err := f.resolveReference(ctx.refsDefinition, base)
-			if err != nil {
-				return err
-			}
-			for k, v := range row {
-				baseRow[k] = v
-			}
-			rows[i] = baseRow
-		}
-	}
-	// build SQL
-	query, err := f.buildInsertQuery(ctx, t, rows)
-	if err != nil {
-		return err
-	}
-	if f.debug {
-		fmt.Println("Issuing SQL:", query)
-	}
-	// issuing query
-	insertedRows, err := tx.Query(query)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = insertedRows.Close() }()
-	// reading results
-	// here I assume that returning rows go in the same
-	// order as values were passed to INSERT statement
-	for _, row := range rows {
-		if !insertedRows.Next() {
-			break
-		}
-		if name, ok := row["$name"]; ok {
-			name := name.(string)
-			if _, ok := ctx.refsDefinition[name]; ok {
-				return fmt.Errorf("duplicating ref name %s", name)
-			}
-			// read values
-			var rowJson string
-			if err := insertedRows.Scan(&rowJson); err != nil {
-				return err
-			}
-			// decode json
-			values := make(map[string]interface{})
-			if err := json.Unmarshal([]byte(rowJson), &values); err != nil {
-				return err
-			}
-			// add to references
-			ctx.refsDefinition[name] = row
-			if f.debug {
-				rowJson, _ := json.Marshal(row)
-				fmt.Printf("Populating ref %s as %s from row definition\n", name, string(rowJson))
-			}
-			ctx.refsInserted[name] = values
-			if f.debug {
-				valuesJson, _ := json.Marshal(values)
-				fmt.Printf("Populating ref %s as %s from inserted values\n", name, string(valuesJson))
-			}
-		}
-	}
-	return err
-}
-
-func (f *Loader) fixSequences(tx *sql.Tx) error {
-	query := `
-DO $$
-DECLARE
-    r record;
-BEGIN
-    FOR r IN (
-        SELECT 'SELECT SETVAL(' || quote_literal(quote_ident(seq_ns.nspname) || '.' || quote_ident(seq.relname))
-            || ', COALESCE(MAX(' || quote_ident(col.attname) || '), 1) ) FROM '
-            || quote_ident(tbl_ns.nspname) || '.' || quote_ident(tbl.relname) AS q
-        FROM pg_class seq
-            JOIN pg_namespace seq_ns ON (seq.relnamespace = seq_ns.oid)
-            JOIN pg_depend dep ON (dep.objid = seq.oid)
-            JOIN pg_class tbl ON (dep.refobjid = tbl.oid)
-            JOIN pg_namespace tbl_ns ON (tbl.relnamespace = tbl_ns.oid)
-            JOIN pg_attribute col ON (col.attrelid = tbl.oid AND dep.refobjsubid = col.attnum)
-        WHERE
-            seq.relkind = 'S'
-        ORDER BY seq.relname
-    ) LOOP
-        EXECUTE r.q;
-    END LOOP;
-END$$
-`
-	if f.debug {
-		fmt.Println("Issuing SQL:", query)
-	}
-	_, err := tx.Exec(query)
-	return err
-}
-
-// buildInsertQuery builds SQL query for data insertion
-// based on values read from yaml
-func (f *Loader) buildInsertQuery(ctx *loadContext, t string, rows table) (string, error) {
-	// first pass, collecting all the fields
-	var fields []string
-	fieldPresence := make(map[string]bool)
-	for _, row := range rows {
-		for name := range row {
-			if len(name) > 0 && name[0] == '$' {
-				continue
-			}
-			if _, ok := fieldPresence[name]; !ok {
-				fieldPresence[name] = true
-				fields = append(fields, name)
-			}
-		}
-	}
-	sort.Strings(fields)
-	// second pass, collecting values
-	dbValues := make([]string, len(rows))
-	for i, row := range rows {
-		dbValuesRow := make([]string, len(fields))
-		for k, name := range fields {
-			value, present := row[name]
-			if !present {
-				dbValuesRow[k] = "default" // default is a PostgreSQL keyword
-				continue
-			}
-			// resolve references
-			if stringValue, ok := value.(string); ok {
-				if len(stringValue) > 0 && stringValue[0] == '$' {
-					var err error
-					dbValuesRow[k], err = f.resolveExpression(stringValue, ctx)
-					if err != nil {
-						return "", err
-					}
-					continue
-				}
-			}
-			dbValue, err := toDbValue(value)
-			if err != nil {
-				return "", fmt.Errorf("unable to process %s value (row %d of %s): %s", name, i, t, err.Error())
-			}
-			dbValuesRow[k] = dbValue
-		}
-		dbValues[i] = "(" + strings.Join(dbValuesRow, ", ") + ")"
-	}
-	// quote fields
-	for i, field := range fields {
-		fields[i] = "\"" + field + "\""
-	}
-
-	tableAlias := t + tempTableSuffix // guarantees that table and column won't collide
-	query := "INSERT INTO \"%s\" AS %s (%s) VALUES %s RETURNING row_to_json(%[2]s)"
-	return fmt.Sprintf(query, t, tableAlias, strings.Join(fields, ", "), strings.Join(dbValues, ", ")), nil
-}
-
-// resolveExpression converts expressions starting with dollar sign into a value
-// supporting expressions:
-// - $eval()               - executes an SQL expression, e.g. $eval(CURRENT_DATE)
-// - $recordName.fieldName - using value of previously inserted named record
-func (f *Loader) resolveExpression(expr string, ctx *loadContext) (string, error) {
-	if expr[:5] == "$eval" {
-		re := regexp.MustCompile(`^\$eval\((.+)\)$`)
-		if matches := re.FindStringSubmatch(expr); matches != nil {
-			return "(" + matches[1] + ")", nil
-		} else {
-			return "", fmt.Errorf("icorrect $eval() usage: %s", expr)
-		}
-	} else {
-		value, err := f.resolveFieldReference(ctx.refsInserted, expr)
-		if err != nil {
-			return "", err
-		}
-		return toDbValue(value)
-	}
-}
-
-// resolveReference finds previously stored reference by its name
-func (f *Loader) resolveReference(refs rowsDict, refName string) (row, error) {
-	target, ok := refs[refName]
-	if !ok {
-		return nil, fmt.Errorf("undefined reference %s", refName)
-	}
-	// make a copy of referencing data to prevent spoiling the source
-	// by the way removing $-records from base row
-	targetCopy := make(row, len(target))
-	for k, v := range target {
-		if len(k) == 0 || k[0] != '$' {
-			targetCopy[k] = v
-		}
-	}
-	return targetCopy, nil
-}
-
-// resolveFieldReference finds previously stored reference by name
-// and return value of its field
-func (f *Loader) resolveFieldReference(refs rowsDict, ref string) (interface{}, error) {
-	parts := strings.SplitN(ref, ".", 2)
-	if len(parts) < 2 || len(parts[0]) < 2 || len(parts[1]) < 1 {
-		return nil, fmt.Errorf("invalid reference %s, correct form is $refName.field", ref)
-	}
-	// remove leading $
-	refName := parts[0][1:]
-	target, ok := refs[refName]
-	if !ok {
-		return nil, fmt.Errorf("undefined reference %s", refName)
-	}
-	value, ok := target[parts[1]]
-	if !ok {
-		return nil, fmt.Errorf("undefined reference field %s", parts[1])
-	}
-	return value, nil
-}
-
-// inArray checks whether the needle is present in haystack slice
-func inArray(needle string, haystack *[]string) bool {
-	for _, e := range *haystack {
-		if needle == e {
-			return true
-		}
-	}
-	return false
-}
-
-// toDbValue prepares value to be passed in SQL query
-// with respect to its type and converts it to string
-func toDbValue(value interface{}) (string, error) {
-	if value == nil {
-		return "NULL", nil
-	}
-	if value, ok := value.(string); ok {
-		return quoteLiteral(value), nil
-	}
-	if value, ok := value.(int); ok {
-		return strconv.Itoa(value), nil
-	}
-	if value, ok := value.(float64); ok {
-		return strconv.FormatFloat(value, 'g', -1, 64), nil
-	}
-	if value, ok := value.(bool); ok {
-		return strconv.FormatBool(value), nil
-	}
-	// the value is either slice or map, so insert it as JSON string
-	// fixme: marshaller doesn't know how to encode map[interface{}]interface{}
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		return "", err
-	}
-	return quoteLiteral(string(encoded)), nil
-}
-
-// quoteLiteral properly escapes string to be safely
-// passed as a value in SQL query
-func quoteLiteral(s string) string {
-	var p string
-	if strings.Contains(s, `\`) {
-		p = "E"
-	}
-	s = strings.Replace(s, `'`, `''`, -1)
-	s = strings.Replace(s, `\`, `\\`, -1)
-	return p + `'` + s + `'`
 }

--- a/fixtures/loader.go
+++ b/fixtures/loader.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/lib/pq"
 
+	"github.com/lamoda/gonkey/fixtures/mysql"
 	"github.com/lamoda/gonkey/fixtures/postgres"
 )
 
@@ -14,10 +15,12 @@ type DbType int
 const (
 	_ = iota
 	Postgres
+	Mysql
 )
 
 const (
 	PostgresParam = "postgres"
+	MysqlParam    = "mysql"
 )
 
 type Config struct {
@@ -44,6 +47,12 @@ func NewLoader(cfg *Config) Loader {
 			location,
 			cfg.Debug,
 		)
+	case Mysql:
+		loader = mysql.New(
+			cfg.DB,
+			location,
+			cfg.Debug,
+		)
 	default:
 		panic("unknown db type")
 	}
@@ -55,6 +64,8 @@ func FetchDbType(dbType string) DbType {
 	switch dbType {
 	case PostgresParam:
 		return Postgres
+	case MysqlParam:
+		return Mysql
 	default:
 		panic("unknown db type param")
 	}

--- a/fixtures/mysql/mysql.go
+++ b/fixtures/mysql/mysql.go
@@ -1,0 +1,554 @@
+package mysql
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type LoaderMysql struct {
+	db       *sql.DB
+	location string
+	debug    bool
+}
+
+const errNoIdColumn = "Error 1054: Unknown column 'id' in 'where clause'"
+
+type row map[string]interface{}
+
+type table []row
+
+type rowsDict map[string]row
+
+type fixture struct {
+	Version   string
+	Inherits  []string
+	Tables    yaml.MapSlice
+	Templates yaml.MapSlice
+}
+
+type loadedTable struct {
+	Name string
+	Rows table
+}
+
+type loadContext struct {
+	files          []string
+	tables         []loadedTable
+	refsDefinition rowsDict
+	refsInserted   rowsDict
+}
+
+func New(db *sql.DB, location string, debug bool) *LoaderMysql {
+	return &LoaderMysql{
+		db:       db,
+		location: location,
+		debug:    debug,
+	}
+}
+
+func (l *LoaderMysql) Load(names []string) error {
+	ctx := loadContext{
+		refsDefinition: make(rowsDict),
+		refsInserted:   make(rowsDict),
+	}
+
+	// gather data from files
+	for _, name := range names {
+		err := l.loadFile(name, &ctx)
+		if err != nil {
+			return fmt.Errorf("unable to load fixture %s: %s", name, err.Error())
+		}
+	}
+
+	return l.loadTables(&ctx)
+}
+
+func (l *LoaderMysql) loadFile(name string, ctx *loadContext) error {
+	candidates := []string{
+		l.location + "/" + name,
+		l.location + "/" + name + ".yml",
+		l.location + "/" + name + ".yaml",
+	}
+
+	var err error
+	var file string
+
+	for _, candidate := range candidates {
+		if _, err = os.Stat(candidate); err == nil {
+			file = candidate
+			break
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	// skip previously loaded files
+	if inArray(file, &(*ctx).files) {
+		return nil
+	}
+
+	l.printDebug("Loading", file)
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	(*ctx).files = append((*ctx).files, file)
+	return l.loadYml(data, ctx)
+}
+
+func (l *LoaderMysql) loadYml(data []byte, ctx *loadContext) error {
+	// read yml into struct
+	var loadedFixture fixture
+	if err := yaml.Unmarshal(data, &loadedFixture); err != nil {
+		return err
+	}
+
+	// load inherits
+	for _, inheritFile := range loadedFixture.Inherits {
+		if err := l.loadFile(inheritFile, ctx); err != nil {
+			return err
+		}
+	}
+
+	for _, template := range loadedFixture.Templates {
+		name := template.Key.(string)
+		if _, ok := ctx.refsDefinition[name]; ok {
+			return fmt.Errorf("unable to load template %s: duplicating ref name", name)
+		}
+
+		fields := template.Value.(yaml.MapSlice)
+		row := make(row, len(fields))
+		for _, field := range fields {
+			key := field.Key.(string)
+			value, _ := field.Value.(interface{})
+			row[key] = value
+		}
+
+		if base, ok := row["$extend"]; ok {
+			base := base.(string)
+			baseRow, err := l.resolveReference(ctx.refsDefinition, base)
+			if err != nil {
+				return err
+			}
+			for k, v := range row {
+				baseRow[k] = v
+			}
+			row = baseRow
+		}
+
+		ctx.refsDefinition[name] = row
+		if l.debug {
+			rowJson, _ := json.Marshal(row)
+			fmt.Printf("Populating ref %s as %s from template\n", name, string(rowJson))
+		}
+	}
+
+	for _, sourceTable := range loadedFixture.Tables {
+		sourceRows, ok := sourceTable.Value.([]interface{})
+		if !ok {
+			return errors.New("expected array at root level")
+		}
+		rows := make(table, len(sourceRows))
+		for i := range sourceRows {
+			sourceFields := sourceRows[i].(yaml.MapSlice)
+			fields := make(row, len(sourceFields))
+			for j := range sourceFields {
+				fields[sourceFields[j].Key.(string)] = sourceFields[j].Value
+			}
+			rows[i] = fields
+		}
+		lt := loadedTable{
+			Name: sourceTable.Key.(string),
+			Rows: rows,
+		}
+		(*ctx).tables = append((*ctx).tables, lt)
+	}
+	return nil
+}
+
+func (l *LoaderMysql) loadTables(ctx *loadContext) error {
+	tx, err := l.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// truncate first
+	truncatedTables := make(map[string]bool)
+	for _, lt := range ctx.tables {
+		if _, ok := truncatedTables[lt.Name]; ok {
+			// already truncated
+			continue
+		}
+		if err := l.truncateTable(tx, lt.Name); err != nil {
+			return err
+		}
+		truncatedTables[lt.Name] = true
+	}
+
+	// then load data
+	for _, lt := range ctx.tables {
+		if len(lt.Rows) == 0 {
+			continue
+		}
+		if err := l.loadTable(tx, ctx, lt.Name, lt.Rows); err != nil {
+			return err
+		}
+	}
+
+	return tx.Commit()
+}
+
+func (l *LoaderMysql) truncateTable(tx *sql.Tx, name string) error {
+	query := fmt.Sprintf("TRUNCATE TABLE `%s`", name)
+
+	l.printDebug("Issuing SQL:", query)
+
+	_, err := tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (l *LoaderMysql) loadTable(tx *sql.Tx, ctx *loadContext, t string, rows table) error {
+
+	// $extend keyword allows to import values from a named row
+	for i, row := range rows {
+		if base, ok := row["$extend"]; ok {
+			base := base.(string)
+			baseRow, err := l.resolveReference(ctx.refsDefinition, base)
+			if err != nil {
+				return err
+			}
+			for k, v := range row {
+				baseRow[k] = v
+			}
+			rows[i] = baseRow
+		}
+	}
+
+	// issuing query
+	for _, row := range rows {
+		if err := l.loadRow(tx, ctx, t, row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *LoaderMysql) loadRow(tx *sql.Tx, ctx *loadContext, t string, row row) error {
+	query, err := l.buildInsertQuery(ctx, t, row)
+	if err != nil {
+		return err
+	}
+	l.printDebug("Issuing SQL:", query)
+
+	insertRes, err := tx.Exec(query)
+	if err != nil {
+		return err
+	}
+
+	// find inserted rows
+	insertedRow, err := l.insertedRows(tx, insertRes, t)
+	defer func() {
+		if insertedRow != nil {
+			_ = insertedRow.Close()
+		}
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	// TODO: we couldn't get insertedRow because don't know Primary Key
+	if insertedRow == nil {
+		return nil
+	}
+
+	if !insertedRow.Next() {
+		return errors.New("can't get inserted row")
+	}
+
+	if name, ok := row["$name"]; ok {
+		name := name.(string)
+		if _, ok := ctx.refsDefinition[name]; ok {
+			return fmt.Errorf("duplicating ref name %s", name)
+		}
+
+		insertedRowValue, err := fetchRow(insertedRow)
+		if err != nil {
+			return err
+		}
+
+		// add to references
+		ctx.refsDefinition[name] = row
+		if l.debug {
+			rowJson, _ := json.Marshal(insertedRowValue)
+			fmt.Printf(
+				"Populating ref %s as %s from row definition\n",
+				name,
+				string(rowJson),
+			)
+		}
+
+		ctx.refsInserted[name] = insertedRowValue
+		if l.debug {
+			valuesJson, _ := json.Marshal(insertedRowValue)
+			fmt.Printf(
+				"Populating ref %s as %s from inserted values\n",
+				name,
+				string(valuesJson),
+			)
+		}
+	}
+
+	return nil
+}
+
+func fetchRow(rows *sql.Rows) (row, error) {
+	res := make(row)
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	rawResult := make([]sql.RawBytes, len(cols))
+
+	dest := make([]interface{}, len(cols))
+	for i := range rawResult {
+		dest[i] = &rawResult[i]
+	}
+
+	// read values
+	if err := rows.Scan(dest...); err != nil {
+		return nil, err
+	}
+
+	for i, raw := range rawResult {
+		if raw == nil {
+			res[cols[i]] = "NULL"
+		} else {
+			res[cols[i]] = string(raw)
+		}
+	}
+
+	return res, nil
+}
+
+func (l *LoaderMysql) insertedRows(tx *sql.Tx, insertRes sql.Result, t string) (*sql.Rows, error) {
+	lastId, err := insertRes.LastInsertId()
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("SELECT * FROM `%s` WHERE `id` = ?", t)
+
+	rows, err := tx.Query(query, lastId)
+	if err != nil {
+		// TODO: now we can take inserted rows only if they have column 'id'
+		//  later we can add possibility to specify name of PK column in fixture definition
+		//  Also, it's weak error check
+		if err.Error() == errNoIdColumn {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	return rows, nil
+}
+
+// buildInsertQuery builds SQL query for data insertion
+// based on values read from yaml
+func (l *LoaderMysql) buildInsertQuery(ctx *loadContext, t string, row row) (string, error) {
+
+	var fields []string
+
+	for name := range row {
+		if strings.HasPrefix(name, "$") {
+			continue
+		}
+		fields = append(fields, name)
+	}
+
+	sort.Strings(fields)
+
+	values := make([]string, len(fields))
+
+	for i, name := range fields {
+		val := row[name]
+
+		v, err := l.rowInsertValue(ctx, val)
+		if err != nil {
+			return "", fmt.Errorf(
+				"unable to process %s value (of %s): %s",
+				name, t, err.Error(),
+			)
+		}
+
+		values[i] = v
+	}
+
+	// quote fields
+	for i, field := range fields {
+		fields[i] = "`" + field + "`"
+	}
+
+	query := "INSERT INTO `%s` (%s) VALUES %s"
+	return fmt.Sprintf(
+		query,
+		t,
+		strings.Join(fields, ", "),
+		"("+strings.Join(values, ", ")+")",
+	), nil
+}
+
+func (l *LoaderMysql) rowInsertValue(ctx *loadContext, val interface{}) (string, error) {
+
+	// resolve references
+	if stringValue, ok := val.(string); ok {
+		if strings.HasPrefix(stringValue, "$") {
+			v, err := l.resolveExpression(stringValue, ctx)
+			if err != nil {
+				return "", err
+			}
+			return v, nil
+		}
+	}
+
+	dbValue, err := toDbValue(val)
+	if err != nil {
+		return "", err
+	}
+	return dbValue, nil
+}
+
+// resolveExpression converts expressions starting with dollar sign into a value
+// supporting expressions:
+// - $eval()               - executes an SQL expression, e.g. $eval(CURRENT_DATE)
+// - $recordName.fieldName - using value of previously inserted named record
+func (l *LoaderMysql) resolveExpression(expr string, ctx *loadContext) (string, error) {
+	if expr[:5] == "$eval" {
+		re := regexp.MustCompile(`^\$eval\((.+)\)$`)
+		if matches := re.FindStringSubmatch(expr); matches != nil {
+			return "(" + matches[1] + ")", nil
+		} else {
+			return "", fmt.Errorf("icorrect $eval() usage: %s", expr)
+		}
+	} else {
+		value, err := l.resolveFieldReference(ctx.refsInserted, expr)
+		if err != nil {
+			return "", err
+		}
+		return toDbValue(value)
+	}
+}
+
+// resolveReference finds previously stored reference by its name
+func (l *LoaderMysql) resolveReference(refs rowsDict, refName string) (row, error) {
+	target, ok := refs[refName]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference %s", refName)
+	}
+	// make a copy of referencing data to prevent spoiling the source
+	// by the way removing $-records from base row
+	targetCopy := make(row, len(target))
+	for k, v := range target {
+		if len(k) == 0 || k[0] != '$' {
+			targetCopy[k] = v
+		}
+	}
+	return targetCopy, nil
+}
+
+// resolveFieldReference finds previously stored reference by name
+// and return value of its field
+func (l *LoaderMysql) resolveFieldReference(refs rowsDict, ref string) (interface{}, error) {
+
+	parts := strings.SplitN(ref, ".", 2)
+	if len(parts) < 2 || len(parts[0]) < 2 || len(parts[1]) < 1 {
+		return nil, fmt.Errorf("invalid reference %s, correct form is $refName.field", ref)
+	}
+
+	// remove leading $
+	refName := parts[0][1:]
+
+	target, ok := refs[refName]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference %s", refName)
+	}
+
+	value, ok := target[parts[1]]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference field %s", parts[1])
+	}
+	return value, nil
+}
+
+// inArray checks whether the needle is present in haystack slice
+func inArray(needle string, haystack *[]string) bool {
+	for _, e := range *haystack {
+		if needle == e {
+			return true
+		}
+	}
+	return false
+}
+
+// toDbValue prepares value to be passed in SQL query
+// with respect to its type and converts it to string
+func toDbValue(value interface{}) (string, error) {
+
+	if value == nil {
+		return "NULL", nil
+	}
+	if value, ok := value.(string); ok {
+		return quoteLiteral(value), nil
+	}
+	if value, ok := value.(int); ok {
+		return strconv.Itoa(value), nil
+	}
+	if value, ok := value.(float64); ok {
+		return strconv.FormatFloat(value, 'g', -1, 64), nil
+	}
+	if value, ok := value.(bool); ok {
+		return strconv.FormatBool(value), nil
+	}
+	// the value is either slice or map, so insert it as JSON string
+	// fixme: marshaller doesn't know how to encode map[interface{}]interface{}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return quoteLiteral(string(encoded)), nil
+}
+
+// quoteLiteral properly escapes string to be safely
+// passed as a value in SQL query
+func quoteLiteral(s string) string {
+	s = strings.Replace(s, `'`, `''`, -1)
+	s = strings.Replace(s, `\`, `\\`, -1)
+	return "'" + s + "'"
+}
+
+func (l *LoaderMysql) printDebug(a ...interface{}) {
+	if l.debug {
+		fmt.Println(a...)
+	}
+}

--- a/fixtures/mysql/mysql_test.go
+++ b/fixtures/mysql/mysql_test.go
@@ -1,0 +1,237 @@
+package mysql
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestBuildInsertQuery(t *testing.T) {
+
+	ymlFile, err := ioutil.ReadFile("../testdata/table.yaml")
+	require.NoError(t, err)
+
+	expected := []string{
+		"INSERT INTO `table` (`field1`, `field2`) VALUES ('value1', 1)",
+		"INSERT INTO `table` (`field1`, `field2`, `field3`) VALUES ('value2', 2, 2.5699477736545666)",
+		"INSERT INTO `table` (`field1`, `field4`, `field5`) VALUES ('\"', false, NULL)",
+		"INSERT INTO `table` (`field1`, `field5`) VALUES ('''', '[1,\"2\"]')",
+	}
+
+	ctx := loadContext{
+		refsDefinition: make(map[string]row),
+		refsInserted:   make(map[string]row),
+	}
+
+	l := New(&sql.DB{}, "", false)
+
+	require.NoError(t,
+		l.loadYml(ymlFile, &ctx),
+	)
+
+	for i, row := range ctx.tables[0].Rows {
+		query, err := l.buildInsertQuery(&ctx, "table", row)
+		require.NoError(t, err)
+
+		assert.Equal(t, expected[i], query)
+	}
+}
+
+func TestLoadTablesShouldResolveRefs(t *testing.T) {
+	yml, err := ioutil.ReadFile("../testdata/table_refs.yaml")
+	require.NoError(t, err)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := loadContext{
+		refsDefinition: make(map[string]row),
+		refsInserted:   make(map[string]row),
+	}
+
+	l := New(db, "", true)
+
+	if err = l.loadYml(yml, &ctx); err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	mock.ExpectBegin()
+
+	expectTruncate(mock, "table1")
+	expectTruncate(mock, "table2")
+	expectTruncate(mock, "table3")
+
+	// table1
+	expectInsert(t, mock,
+		"table1",
+		[]string{"f1", "f2"},
+		"\\('value1', 'value2'\\)",
+		[]string{"value1", "value2"},
+	)
+
+	// table2
+	expectInsert(t, mock,
+		"table2",
+		[]string{"f1", "f2"},
+		"\\('value2', 'value1'\\)",
+		[]string{"value2", "value1"},
+	)
+
+	// table1
+	expectInsert(t, mock,
+		"table3",
+		[]string{"f1", "f2"},
+		"\\('value1', 'value2'\\)",
+		[]string{"value1", "value2"},
+	)
+
+	mock.ExpectCommit()
+
+	err = l.loadTables(&ctx)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+		t.Fail()
+	}
+}
+
+func TestLoadTablesShouldExtendRows(t *testing.T) {
+	yml, err := ioutil.ReadFile("../testdata/table_extend.yaml")
+	require.NoError(t, err)
+
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := loadContext{
+		refsDefinition: make(map[string]row),
+		refsInserted:   make(map[string]row),
+	}
+
+	l := New(db, "", true)
+
+	if err = l.loadYml(yml, &ctx); err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	mock.ExpectBegin()
+
+	expectTruncate(mock, "table1")
+	expectTruncate(mock, "table2")
+	expectTruncate(mock, "table3")
+
+	// table1
+	expectInsert(t, mock,
+		"table1",
+		[]string{"f1", "f2"},
+		"\\('value1', 'value2'\\)",
+		[]string{"value1", "value2"},
+	)
+
+	// table2
+	expectInsert(t, mock,
+		"table2",
+		[]string{"f1", "f2", "f3"},
+		"\\('value1 overwritten', 'value2', "+`\("1" \|\| "2" \|\| 3 \+ 5\)\)$`,
+		[]string{"value1 overwritten", "value2", `1`},
+	)
+
+	// table3, data 1
+	expectInsert(t, mock,
+		"table3",
+		[]string{"f1", "f2", "f3"},
+		"\\('value1 overwritten', 'value2', "+`\("1" \|\| "2" \|\| 3 \+ 5\)\)$`,
+		[]string{"value1 overwritten", "value2", `1`},
+	)
+
+	// table3, data 2
+	expectInsert(t, mock,
+		"table3",
+		[]string{"f1", "f2"},
+		"\\('tplVal1', 'tplVal2'\\)",
+		[]string{"tplVal1", "tplVal2"},
+	)
+
+	mock.ExpectCommit()
+
+	err = l.loadTables(&ctx)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("there were unfulfilled expectations: %s", err)
+		t.Fail()
+	}
+}
+
+var idCounter int64
+
+func expectInsert(
+	t *testing.T,
+	mock sqlmock.Sqlmock,
+	table string,
+	fields []string,
+	valuesToInsert string,
+	valuesResult []string,
+) {
+
+	t.Helper()
+
+	idCounter++
+
+	mock.ExpectExec(
+		fmt.Sprintf("^INSERT INTO `%s` %s VALUES %s$",
+			table,
+			fieldsToDbStr(fields),
+			valuesToInsert,
+		),
+	).
+		WillReturnResult(sqlmock.NewResult(idCounter, 1))
+
+	var valuesRow []driver.Value
+	for _, v := range valuesResult {
+		valuesRow = append(valuesRow, driver.Value(v))
+	}
+
+	mock.ExpectQuery(fmt.Sprintf("^SELECT \\* FROM `%s` WHERE `id` = \\?$", table)).
+		WithArgs(idCounter).
+		WillReturnRows(
+			sqlmock.NewRows(fields).
+				AddRow(valuesRow...),
+		)
+}
+
+func expectTruncate(mock sqlmock.Sqlmock, table string) {
+	mock.ExpectExec(fmt.Sprintf("^TRUNCATE TABLE `%s`$", table)).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+}
+
+func fieldsToDbStr(values []string) string {
+	quotedVals := make([]string, len(values))
+
+	for i, val := range values {
+		quotedVals[i] = "`" + val + "`"
+	}
+
+	return "\\(" + strings.Join(quotedVals, ", ") + "\\)"
+}

--- a/fixtures/postgres/postgres.go
+++ b/fixtures/postgres/postgres.go
@@ -1,0 +1,496 @@
+package postgres
+
+import (
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type LoaderPostgres struct {
+	db       *sql.DB
+	location string
+	debug    bool
+}
+
+const tempTableSuffix = "_table_gonkey"
+
+type row map[string]interface{}
+
+type table []row
+
+type rowsDict map[string]row
+
+type fixture struct {
+	Version   string
+	Inherits  []string
+	Tables    yaml.MapSlice
+	Templates yaml.MapSlice
+}
+
+type loadedTable struct {
+	Name string
+	Rows table
+}
+
+type loadContext struct {
+	files          []string
+	tables         []loadedTable
+	refsDefinition rowsDict
+	refsInserted   rowsDict
+}
+
+func New(db *sql.DB, location string, debug bool) *LoaderPostgres {
+	return &LoaderPostgres{
+		db:       db,
+		location: location,
+		debug:    debug,
+	}
+}
+
+func (f *LoaderPostgres) Load(names []string) error {
+	ctx := loadContext{
+		refsDefinition: make(rowsDict),
+		refsInserted:   make(rowsDict),
+	}
+	// gather data from files
+	for _, name := range names {
+		err := f.loadFile(name, &ctx)
+		if err != nil {
+			return fmt.Errorf("unable to load fixture %s: %s", name, err.Error())
+		}
+	}
+	return f.loadTables(&ctx)
+}
+
+func (f *LoaderPostgres) loadFile(name string, ctx *loadContext) error {
+	candidates := []string{
+		f.location + "/" + name,
+		f.location + "/" + name + ".yml",
+		f.location + "/" + name + ".yaml",
+	}
+	var err error
+	var file string
+	for _, candidate := range candidates {
+		if _, err = os.Stat(candidate); err == nil {
+			file = candidate
+			break
+		}
+	}
+	if err != nil {
+		return err
+	}
+	// skip previously loaded files
+	if inArray(file, &(*ctx).files) {
+		return nil
+	}
+	if f.debug {
+		fmt.Println("Loading", file)
+	}
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return err
+	}
+	(*ctx).files = append((*ctx).files, file)
+	return f.loadYml(data, ctx)
+}
+
+func (f *LoaderPostgres) loadYml(data []byte, ctx *loadContext) error {
+	// read yml into struct
+	var loadedFixture fixture
+	if err := yaml.Unmarshal(data, &loadedFixture); err != nil {
+		return err
+	}
+
+	// load inherits
+	for _, inheritFile := range loadedFixture.Inherits {
+		if err := f.loadFile(inheritFile, ctx); err != nil {
+			return err
+		}
+	}
+
+	// loadedFixture.Templates
+	// yaml.MapSlice{
+	//    string => yaml.MapSlice{
+	//        string => interface{}
+	//    }
+	// }
+	for _, template := range loadedFixture.Templates {
+		name := template.Key.(string)
+		if _, ok := ctx.refsDefinition[name]; ok {
+			return fmt.Errorf("unable to load template %s: duplicating ref name", name)
+		}
+		fields := template.Value.(yaml.MapSlice)
+		row := make(row, len(fields))
+		for _, field := range fields {
+			key := field.Key.(string)
+			value, _ := field.Value.(interface{})
+			row[key] = value
+		}
+		if base, ok := row["$extend"]; ok {
+			base := base.(string)
+			baseRow, err := f.resolveReference(ctx.refsDefinition, base)
+			if err != nil {
+				return err
+			}
+			for k, v := range row {
+				baseRow[k] = v
+			}
+			row = baseRow
+		}
+		ctx.refsDefinition[name] = row
+		if f.debug {
+			rowJson, _ := json.Marshal(row)
+			fmt.Printf("Populating ref %s as %s from template\n", name, string(rowJson))
+		}
+	}
+
+	// loadedFixture.Tables
+	// yaml.MapSlice{
+	//    string => []interface{
+	//        yaml.MapSlice{
+	//            string => interface{}
+	//        }
+	//    }
+	// }
+	for _, sourceTable := range loadedFixture.Tables {
+		sourceRows, ok := sourceTable.Value.([]interface{})
+		if !ok {
+			return errors.New("expected array at root level")
+		}
+		rows := make(table, len(sourceRows))
+		for i := range sourceRows {
+			sourceFields := sourceRows[i].(yaml.MapSlice)
+			fields := make(row, len(sourceFields))
+			for j := range sourceFields {
+				fields[sourceFields[j].Key.(string)] = sourceFields[j].Value
+			}
+			rows[i] = fields
+		}
+		lt := loadedTable{
+			Name: sourceTable.Key.(string),
+			Rows: rows,
+		}
+		(*ctx).tables = append((*ctx).tables, lt)
+	}
+	return nil
+}
+
+func (f *LoaderPostgres) loadTables(ctx *loadContext) error {
+	tx, err := f.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// truncate first
+	truncatedTables := make(map[string]bool)
+	for _, lt := range ctx.tables {
+		if _, ok := truncatedTables[lt.Name]; ok {
+			// already truncated
+			continue
+		}
+		if err := f.truncateTable(lt.Name); err != nil {
+			return err
+		}
+		truncatedTables[lt.Name] = true
+	}
+	// then load data
+	for _, lt := range ctx.tables {
+		if len(lt.Rows) == 0 {
+			continue
+		}
+		if err := f.loadTable(ctx, lt.Name, lt.Rows); err != nil {
+			return err
+		}
+	}
+	// alter the sequences so they contain max id + 1
+	if err := f.fixSequences(); err != nil {
+		return err
+	}
+
+	return tx.Commit()
+}
+
+// truncateTable truncates table
+func (f *LoaderPostgres) truncateTable(name string) error {
+	query := fmt.Sprintf("TRUNCATE TABLE \"%s\" CASCADE", name)
+	if f.debug {
+		fmt.Println("Issuing SQL:", query)
+	}
+	_, err := f.db.Exec(query)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *LoaderPostgres) loadTable(ctx *loadContext, t string, rows table) error {
+	// $extend keyword allows to import values from a named row
+	for i, row := range rows {
+		if base, ok := row["$extend"]; ok {
+			base := base.(string)
+			baseRow, err := f.resolveReference(ctx.refsDefinition, base)
+			if err != nil {
+				return err
+			}
+			for k, v := range row {
+				baseRow[k] = v
+			}
+			rows[i] = baseRow
+		}
+	}
+	// build SQL
+	query, err := f.buildInsertQuery(ctx, t, rows)
+	if err != nil {
+		return err
+	}
+	if f.debug {
+		fmt.Println("Issuing SQL:", query)
+	}
+	// issuing query
+	insertedRows, err := f.db.Query(query)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = insertedRows.Close() }()
+	// reading results
+	// here I assume that returning rows go in the same
+	// order as values were passed to INSERT statement
+	for _, row := range rows {
+		if !insertedRows.Next() {
+			break
+		}
+		if name, ok := row["$name"]; ok {
+			name := name.(string)
+			if _, ok := ctx.refsDefinition[name]; ok {
+				return fmt.Errorf("duplicating ref name %s", name)
+			}
+			// read values
+			var rowJson string
+			if err := insertedRows.Scan(&rowJson); err != nil {
+				return err
+			}
+			// decode json
+			values := make(map[string]interface{})
+			if err := json.Unmarshal([]byte(rowJson), &values); err != nil {
+				return err
+			}
+			// add to references
+			ctx.refsDefinition[name] = row
+			if f.debug {
+				rowJson, _ := json.Marshal(row)
+				fmt.Printf("Populating ref %s as %s from row definition\n", name, string(rowJson))
+			}
+			ctx.refsInserted[name] = values
+			if f.debug {
+				valuesJson, _ := json.Marshal(values)
+				fmt.Printf("Populating ref %s as %s from inserted values\n", name, string(valuesJson))
+			}
+		}
+	}
+	return err
+}
+
+func (f *LoaderPostgres) fixSequences() error {
+	query := `
+DO $$
+DECLARE
+    r record;
+BEGIN
+    FOR r IN (
+        SELECT 'SELECT SETVAL(' || quote_literal(quote_ident(seq_ns.nspname) || '.' || quote_ident(seq.relname))
+            || ', COALESCE(MAX(' || quote_ident(col.attname) || '), 1) ) FROM '
+            || quote_ident(tbl_ns.nspname) || '.' || quote_ident(tbl.relname) AS q
+        FROM pg_class seq
+            JOIN pg_namespace seq_ns ON (seq.relnamespace = seq_ns.oid)
+            JOIN pg_depend dep ON (dep.objid = seq.oid)
+            JOIN pg_class tbl ON (dep.refobjid = tbl.oid)
+            JOIN pg_namespace tbl_ns ON (tbl.relnamespace = tbl_ns.oid)
+            JOIN pg_attribute col ON (col.attrelid = tbl.oid AND dep.refobjsubid = col.attnum)
+        WHERE
+            seq.relkind = 'S'
+        ORDER BY seq.relname
+    ) LOOP
+        EXECUTE r.q;
+    END LOOP;
+END$$
+`
+	if f.debug {
+		fmt.Println("Issuing SQL:", query)
+	}
+	_, err := f.db.Exec(query)
+	return err
+}
+
+// buildInsertQuery builds SQL query for data insertion
+// based on values read from yaml
+func (f *LoaderPostgres) buildInsertQuery(ctx *loadContext, t string, rows table) (string, error) {
+	// first pass, collecting all the fields
+	var fields []string
+	fieldPresence := make(map[string]bool)
+	for _, row := range rows {
+		for name := range row {
+			if len(name) > 0 && name[0] == '$' {
+				continue
+			}
+			if _, ok := fieldPresence[name]; !ok {
+				fieldPresence[name] = true
+				fields = append(fields, name)
+			}
+		}
+	}
+	sort.Strings(fields)
+	// second pass, collecting values
+	dbValues := make([]string, len(rows))
+	for i, row := range rows {
+		dbValuesRow := make([]string, len(fields))
+		for k, name := range fields {
+			value, present := row[name]
+			if !present {
+				dbValuesRow[k] = "default" // default is a PostgreSQL keyword
+				continue
+			}
+			// resolve references
+			if stringValue, ok := value.(string); ok {
+				if len(stringValue) > 0 && stringValue[0] == '$' {
+					var err error
+					dbValuesRow[k], err = f.resolveExpression(stringValue, ctx)
+					if err != nil {
+						return "", err
+					}
+					continue
+				}
+			}
+			dbValue, err := toDbValue(value)
+			if err != nil {
+				return "", fmt.Errorf("unable to process %s value (row %d of %s): %s", name, i, t, err.Error())
+			}
+			dbValuesRow[k] = dbValue
+		}
+		dbValues[i] = "(" + strings.Join(dbValuesRow, ", ") + ")"
+	}
+	// quote fields
+	for i, field := range fields {
+		fields[i] = "\"" + field + "\""
+	}
+
+	tableAlias := t + tempTableSuffix // guarantees that table and column won't collide
+	query := "INSERT INTO \"%s\" AS %s (%s) VALUES %s RETURNING row_to_json(%[2]s)"
+	return fmt.Sprintf(query, t, tableAlias, strings.Join(fields, ", "), strings.Join(dbValues, ", ")), nil
+}
+
+// resolveExpression converts expressions starting with dollar sign into a value
+// supporting expressions:
+// - $eval()               - executes an SQL expression, e.g. $eval(CURRENT_DATE)
+// - $recordName.fieldName - using value of previously inserted named record
+func (f *LoaderPostgres) resolveExpression(expr string, ctx *loadContext) (string, error) {
+	if expr[:5] == "$eval" {
+		re := regexp.MustCompile(`^\$eval\((.+)\)$`)
+		if matches := re.FindStringSubmatch(expr); matches != nil {
+			return "(" + matches[1] + ")", nil
+		} else {
+			return "", fmt.Errorf("icorrect $eval() usage: %s", expr)
+		}
+	} else {
+		value, err := f.resolveFieldReference(ctx.refsInserted, expr)
+		if err != nil {
+			return "", nil
+		}
+		return toDbValue(value)
+	}
+}
+
+// resolveReference finds previously stored reference by its name
+func (f *LoaderPostgres) resolveReference(refs rowsDict, refName string) (row, error) {
+	target, ok := refs[refName]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference %s", refName)
+	}
+	// make a copy of referencing data to prevent spoiling the source
+	// by the way removing $-records from base row
+	targetCopy := make(row, len(target))
+	for k, v := range target {
+		if len(k) == 0 || k[0] != '$' {
+			targetCopy[k] = v
+		}
+	}
+	return targetCopy, nil
+}
+
+// resolveFieldReference finds previously stored reference by name
+// and return value of its field
+func (f *LoaderPostgres) resolveFieldReference(refs rowsDict, ref string) (interface{}, error) {
+	parts := strings.SplitN(ref, ".", 2)
+	if len(parts) < 2 || len(parts[0]) < 2 || len(parts[1]) < 1 {
+		return nil, fmt.Errorf("invalid reference %s, correct form is $refName.field", ref)
+	}
+	// remove leading $
+	refName := parts[0][1:]
+	target, ok := refs[refName]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference %s", refName)
+	}
+	value, ok := target[parts[1]]
+	if !ok {
+		return nil, fmt.Errorf("undefined reference field %s", parts[1])
+	}
+	return value, nil
+}
+
+// inArray checks whether the needle is present in haystack slice
+func inArray(needle string, haystack *[]string) bool {
+	for _, e := range *haystack {
+		if needle == e {
+			return true
+		}
+	}
+	return false
+}
+
+// toDbValue prepares value to be passed in SQL query
+// with respect to its type and converts it to string
+func toDbValue(value interface{}) (string, error) {
+	if value == nil {
+		return "NULL", nil
+	}
+	if value, ok := value.(string); ok {
+		return quoteLiteral(value), nil
+	}
+	if value, ok := value.(int); ok {
+		return strconv.Itoa(value), nil
+	}
+	if value, ok := value.(float64); ok {
+		return strconv.FormatFloat(value, 'g', -1, 64), nil
+	}
+	if value, ok := value.(bool); ok {
+		return strconv.FormatBool(value), nil
+	}
+	// the value is either slice or map, so insert it as JSON string
+	// fixme: marshaller doesn't know how to encode map[interface{}]interface{}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return quoteLiteral(string(encoded)), nil
+}
+
+// quoteLiteral properly escapes string to be safely
+// passed as a value in SQL query
+func quoteLiteral(s string) string {
+	var p string
+	if strings.Contains(s, `\`) {
+		p = "E"
+	}
+	s = strings.Replace(s, `'`, `''`, -1)
+	s = strings.Replace(s, `\`, `\\`, -1)
+	return p + `'` + s + `'`
+}

--- a/fixtures/testdata/table.yaml
+++ b/fixtures/testdata/table.yaml
@@ -1,0 +1,14 @@
+tables:
+  table:
+    - field1: "value1"
+      field2: 1
+    - field1: "value2"
+      field2: 2
+      field3: 2.569947773654566473
+    - field4: false
+      field5: null
+      field1: '"'
+    - field1: "'"
+      field5:
+        - 1
+        - '2'

--- a/fixtures/testdata/table_extend.yaml
+++ b/fixtures/testdata/table_extend.yaml
@@ -1,0 +1,21 @@
+templates:
+  baseTpl:
+    f1: tplVal1
+  ref3:
+    $extend: baseTpl
+    f2: tplVal2
+tables:
+  table1:
+    - $name: ref1
+      f1: value1
+      f2: value2
+
+  table2:
+    - $name: ref2
+      $extend: ref1
+      f1: value1 overwritten
+      f3: $eval("1" || "2" || 3 + 5)
+
+  table3:
+    - $extend: ref2
+    - $extend: ref3

--- a/fixtures/testdata/table_refs.yaml
+++ b/fixtures/testdata/table_refs.yaml
@@ -1,0 +1,14 @@
+tables:
+  table1:
+    - $name: ref1
+      f1: value1
+      f2: value2
+
+  table2:
+    - $name: ref2
+      f1: $ref1.f2
+      f2: $ref1.f1
+
+  table3:
+    - f1: $ref1.f1
+      f2: $ref2.f1

--- a/main.go
+++ b/main.go
@@ -40,11 +40,16 @@ func main() {
 	flag.StringVar(&config.TestsLocation, "tests", "", "Path to tests file or directory")
 	flag.StringVar(&config.DbDsn, "db_dsn", "", "DSN for the fixtures database (WARNING! Db tables will be truncated)")
 	flag.StringVar(&config.FixturesLocation, "fixtures", "", "Path to fixtures directory")
-	flag.StringVar(&config.EnvFile, "db-type", fixtures.PostgresParam, "Type of database (options: postgres)")
 	flag.StringVar(&config.EnvFile, "env-file", "", "Path to env-file")
 	flag.BoolVar(&config.Allure, "allure", true, "Make Allure report")
 	flag.BoolVar(&config.Verbose, "v", false, "Verbose output")
 	flag.BoolVar(&config.Debug, "debug", false, "Debug output")
+	flag.StringVar(
+		&config.EnvFile,
+		"db-type",
+		fixtures.PostgresParam,
+		"Type of database (options: postgres, mysql)",
+	)
 
 	flag.Parse()
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func main() {
 		Allure           bool
 		Verbose          bool
 		Debug            bool
+		DbType           string
 	}
 
 	flag.StringVar(&config.Host, "host", "", "Target system hostname")
@@ -39,6 +40,7 @@ func main() {
 	flag.StringVar(&config.TestsLocation, "tests", "", "Path to tests file or directory")
 	flag.StringVar(&config.DbDsn, "db_dsn", "", "DSN for the fixtures database (WARNING! Db tables will be truncated)")
 	flag.StringVar(&config.FixturesLocation, "fixtures", "", "Path to fixtures directory")
+	flag.StringVar(&config.EnvFile, "db-type", fixtures.PostgresParam, "Type of database (options: postgres)")
 	flag.StringVar(&config.EnvFile, "env-file", "", "Path to env-file")
 	flag.BoolVar(&config.Allure, "allure", true, "Make Allure report")
 	flag.BoolVar(&config.Verbose, "v", false, "Verbose output")
@@ -68,12 +70,13 @@ func main() {
 		}
 	}
 
-	var fixturesLoader *fixtures.Loader
+	var fixturesLoader fixtures.Loader
 	if db != nil && config.FixturesLocation != "" {
 		fixturesLoader = fixtures.NewLoader(&fixtures.Config{
 			DB:       db,
 			Location: config.FixturesLocation,
 			Debug:    config.Debug,
+			DbType:   fixtures.FetchDbType(config.DbType),
 		})
 	} else if config.FixturesLocation != "" {
 		log.Fatal(errors.New("you should specify db_dsn to load fixtures"))

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -19,7 +19,7 @@ import (
 
 type Config struct {
 	Host           string
-	FixturesLoader *fixtures.Loader
+	FixturesLoader fixtures.Loader
 	Mocks          *mocks.Mocks
 	MocksLoader    *mocks.Loader
 	Variables      *variables.Variables

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -25,6 +25,7 @@ type RunWithTestingParams struct {
 	Mocks       *mocks.Mocks
 	FixturesDir string
 	DB          *sql.DB
+	DbType      fixtures.DbType
 	EnvFilePath string
 }
 
@@ -44,12 +45,13 @@ func RunWithTesting(t *testing.T, params *RunWithTestingParams) {
 
 	debug := os.Getenv("GONKEY_DEBUG") != ""
 
-	var fixturesLoader *fixtures.Loader
+	var fixturesLoader fixtures.Loader
 	if params.DB != nil {
 		fixturesLoader = fixtures.NewLoader(&fixtures.Config{
 			Location: params.FixturesDir,
 			DB:       params.DB,
 			Debug:    debug,
+			DbType:   params.DbType,
 		})
 	}
 


### PR DESCRIPTION
List of changes:

- postgres loader extracted to own package
- added common interface instead of specific loader
- added param db-type to specify the database type
    (only postgres is supported now)
- test-cases definition extracted to separate files from code
    (for more clarity and for shared access between tests for other DBs)
- added param DbType to RunWithTestingParams
- **added mysql support**