### PR TITLE
support variables in case body

### DIFF
--- a/testloader/yaml_file/parser.go
+++ b/testloader/yaml_file/parser.go
@@ -71,6 +71,14 @@ func makeTestFromDefinition(testDefinition TestDefinition) ([]Test, error) {
 		test := Test{TestDefinition: testDefinition}
 		test.Name = fmt.Sprintf("%s #%d", test.Name, caseIdx)
 
+		// load variables from case
+		if test.Variables == nil {
+			test.Variables = map[string]string{}
+		}
+		for key, value := range testCase.Variables {
+			test.Variables[key] = value
+		}
+
 		// compile request body
 		test.Request, err = executeTmpl(requestTmpl, testCase.RequestArgs)
 

--- a/testloader/yaml_file/test_definition.go
+++ b/testloader/yaml_file/test_definition.go
@@ -26,6 +26,7 @@ type TestDefinition struct {
 }
 
 type CaseData struct {
+	Variables        map[string]string              `json:"variables" yaml:"variables"`
 	RequestArgs      map[string]interface{}         `json:"requestArgs" yaml:"requestArgs"`
 	ResponseArgs     map[int]map[string]interface{} `json:"responseArgs" yaml:"responseArgs"`
 	BeforeScriptArgs map[string]interface{}         `json:"beforeScriptArgs" yaml:"beforeScriptArgs"`

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -23,7 +23,7 @@ func New() *Variables {
 // Load adds new variables and replaces values of existing
 func (vs *Variables) Load(variables map[string]string) {
 	for n, v := range variables {
-		variable := NewVariable(n, v)
+		variable := NewVariable(n, vs.perform(v))
 
 		vs.variables[n] = variable
 	}


### PR DESCRIPTION
Add support for variables in "case" like this

1)
```
- name: delete existing user MUST be success
  method: DELETE
  path: /users/{{ $userName }}
  response:
    204:
  cases:
    - variables:
        userName: "TestUsers-user1"
    - variables:
        userName: "TestUsers-user2"
```

2) and for more complicated case like  
```
- name: MUST fail operation with insufficient privileges
  method: DELETE
  path: /users/someUserName
  headers:
    Authorization: "Bearer {{ $jwt }}"
  response:
    403:
  cases:
    - variables:
        jwt: "{{ $otherUserJwt }}"
    - variables:
        jwt: "{{ $readOnlyJwt }}"
```
where "otherUserJwt" and "readOnlyJwt" declared in env-file.