### PR TITLE
Fail if fixture not loaded

### DIFF
--- a/fixtures/postgres/postgres.go
+++ b/fixtures/postgres/postgres.go
@@ -209,7 +209,7 @@ func (f *LoaderPostgres) loadTables(ctx *loadContext) error {
 			continue
 		}
 		if err := f.loadTable(ctx, lt.Name, lt.Rows); err != nil {
-			return err
+			return fmt.Errorf("failed to load table '%s' because:\n%s", lt.Name, err)
 		}
 	}
 	// alter the sequences so they contain max id + 1
@@ -296,6 +296,14 @@ func (f *LoaderPostgres) loadTable(ctx *loadContext, t string, rows table) error
 				fmt.Printf("Populating ref %s as %s from inserted values\n", name, string(valuesJson))
 			}
 		}
+	}
+
+	// iterate through any remaining rows and check for an error
+	for insertedRows.Next() {
+		continue
+	}
+	if err := insertedRows.Err(); err != nil {
+		return fmt.Errorf("failed to execute query. DB returned error:\n%s", err)
 	}
 	return err
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -74,6 +74,7 @@ func (r *Runner) Run() (*models.Summary, error) {
 	for v := range loader {
 		testResult, err := r.executeTest(v, client)
 		if err != nil {
+			// todo: populate error with test name. Currently it is not possible here to get test name.
 			return nil, err
 		}
 		totalTests++
@@ -104,7 +105,7 @@ func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*mode
 	// load fixtures
 	if r.config.FixturesLoader != nil && v.Fixtures() != nil {
 		if err := r.config.FixturesLoader.Load(v.Fixtures()); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("unable to load fixtures [%s], error:\n%s", strings.Join(v.Fixtures(), ", "), err)
 		}
 	}
 


### PR DESCRIPTION
Currently if fixture fails to load due to DB constraints you will not see any error and won't know about this issue.
This PR solves this and stops test immediately with error like:

>     runner_testing.go:95: unable to load fixtures [subsets_fittings, reviews], error:
>         failed to load table 'subsets_fittingmeasurements' because:
>         failed to execute query. DB returned error:
>         pq: insert or update on table "subsets_fittingmeasurements" violates foreign key constraint "subsets_fittingmeasu_measurement_type_3668939d_fk_reviews_m"
> --- FAIL: TestGonkey (7.21s)

Error formatting is a bit ugly and there is still room for improvement but it applies for all errors in Gonkey and should be solved globally in another PR.