### PR TITLE
Problem .yaml file is not shown in error

### DIFF
--- a/testloader/yaml_file/parser.go
+++ b/testloader/yaml_file/parser.go
@@ -12,14 +12,14 @@ import (
 func parseTestDefinitionFile(absPath string) ([]Test, error) {
 	data, err := ioutil.ReadFile(absPath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read file %s:\n%s", absPath, err)
 	}
 
 	var testDefinitions []TestDefinition
 
 	// reading the test source file
 	if err := yaml.Unmarshal(data, &testDefinitions); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to unmarshall %s:\n%s", absPath, err)
 	}
 
 	var tests []Test


### PR DESCRIPTION
Error output before:

    runner_testing.go:95: yaml: line 82: did not find expected key
    --- FAIL: TestGonkey (44.46s)
    FAIL

Error output after:

    runner_testing.go:95: failed to unmarshall ./cases/subsets/fittings_get.yaml:
        yaml: line 77: did not find expected key
    --- FAIL: TestGonkey (0.03s)
    FAIL