### PR TITLE
fix error "mock ...: http: invalid Read on closed Body"

### DIFF
--- a/mocks/definition.go
+++ b/mocks/definition.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"fmt"
 	"net/http"
+	"net/http/httputil"
 	"sync"
 )
 
@@ -32,13 +33,18 @@ func (d *definition) Execute(w http.ResponseWriter, r *http.Request) []error {
 	d.Unlock()
 	var errors []error
 	if len(d.requestConstraints) > 0 {
+		requestDump, err := httputil.DumpRequest(r, true)
+		if err != nil {
+			fmt.Printf("Gonkey internal error: %s\n", err)
+		}
+
 		for _, c := range d.requestConstraints {
 			errs := c.Verify(r)
 			for _, e := range errs {
 				errors = append(errors, &RequestConstraintError{
-					error:      e,
-					Constraint: c,
-					Request:    r,
+					error:       e,
+					Constraint:  c,
+					RequestDump: requestDump,
 				})
 			}
 		}

--- a/mocks/error.go
+++ b/mocks/error.go
@@ -2,8 +2,6 @@ package mocks
 
 import (
 	"fmt"
-	"net/http"
-	"net/http/httputil"
 	"reflect"
 )
 
@@ -18,15 +16,11 @@ func (e *Error) Error() string {
 
 type RequestConstraintError struct {
 	error
-	Constraint verifier
-	Request    *http.Request
+	Constraint  verifier
+	RequestDump []byte
 }
 
 func (e *RequestConstraintError) Error() string {
 	kind := reflect.TypeOf(e.Constraint).String()
-	req, err := httputil.DumpRequest(e.Request, true)
-	if err != nil {
-		return err.Error()
-	}
-	return fmt.Sprintf("request constraint %s failed: %s, request was:\n %s", kind, e.error.Error(), req)
+	return fmt.Sprintf("request constraint %s failed: %s, request was:\n %s", kind, e.error.Error(), e.RequestDump)
 }


### PR DESCRIPTION
On constraint error for mocks I saw only "mock ...: http: invalid Read on closed Body" instead of real problem. 

Bug was in code 
```
func (e *RequestConstraintError) Error() string {
	kind := reflect.TypeOf(e.Constraint).String()
	req, err := httputil.DumpRequest(e.Request, true)
	if err != nil {
		return err.Error()          <---- error from here!
	}
	return fmt.Sprintf("request constraint %s failed: %s, request was:\n %s", kind, e.error.Error(), req)
}
```
This error (from httputil.DumpRequest) rewrites original one.