### PR TITLE
new: added constraints for url path

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -668,6 +668,29 @@ runner.RunWithTesting(t, &runner.RunWithTestingParams{
   ...
 ```
 
+###### pathMatches
+
+Проверяет, что путь в запросе соответствует заданному значению.
+
+Параметры:
+- `path` - строка, которой должен быть равен путь запроса;
+- `regexp` - регулярное выражение, которому должен соответствовать путь запроса.
+
+Пример:
+```yaml
+  ...
+  mocks:
+    service1:
+      requestConstraints:
+        - kind: pathMatches
+          path: /api/v1/test/somevalue
+    service2:
+      requestConstraints:
+        - kind: pathMatches
+          regexp: ^/api/v1/test/.*$
+    ...
+```
+
 ###### queryMatches
 
 Проверяет, что параметры GET запроса соответствуют заданным в параметре `query`.

--- a/README.md
+++ b/README.md
@@ -666,6 +666,29 @@ Origin request that contains string-packed JSON
   ...
 ```
 
+###### pathMatches
+
+Checks that the request path corresponds to the expected one.
+
+Parameters:
+- `path` - a string with the expected request path value;
+- `regexp` - a regular expression to check the path value against.
+
+Example:
+```yaml
+  ...
+  mocks:
+    service1:
+      requestConstraints:
+        - kind: pathMatches
+          path: /api/v1/test/somevalue
+    service2:
+      requestConstraints:
+        - kind: pathMatches
+          regexp: ^/api/v1/test/.*$
+    ...
+```
+
 ###### queryMatches
 
 Checks that the GET request parameters correspond to the ones defined in the `query` parameter.

--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -284,6 +284,9 @@ func (l *Loader) loadConstraintOfKind(kind string, def map[interface{}]interface
 	case "headerIs":
 		*ak = append(*ak, "header", "value", "regexp")
 		return l.loadHeaderIsConstraint(def)
+	case "pathMatches":
+		*ak = append(*ak, "path", "regexp")
+		return l.loadPathMatchesConstraint(def)
 	case "bodyMatchesXML":
 		*ak = append(*ak, "body")
 		return l.loadBodyMatchesXMLConstraint(def)
@@ -335,6 +338,23 @@ func (l *Loader) loadBodyMatchesXMLConstraint(def map[interface{}]interface{}) (
 		return nil, errors.New("`body` must be string")
 	}
 	return newBodyMatchesXMLConstraint(body)
+}
+
+func (l *Loader) loadPathMatchesConstraint(def map[interface{}]interface{}) (verifier, error) {
+	var pathStr, regexpStr string
+	if path, ok := def["path"]; ok {
+		pathStr, ok = path.(string)
+		if !ok {
+			return nil, errors.New("`path` must be string")
+		}
+	}
+	if regexp, ok := def["regexp"]; ok {
+		regexpStr, ok = regexp.(string)
+		if !ok || regexp == "" {
+			return nil, errors.New("`regexp` must be string")
+		}
+	}
+	return newPathConstraint(pathStr, regexpStr)
 }
 
 func (l *Loader) loadQueryMatchesConstraint(def map[interface{}]interface{}) (verifier, error) {

--- a/mocks/request_constraint.go
+++ b/mocks/request_constraint.go
@@ -242,3 +242,37 @@ func (c *queryConstraint) Verify(r *http.Request) (errors []error) {
 
 	return errors
 }
+
+type pathConstraint struct {
+	verifier
+
+	path   string
+	regexp *regexp.Regexp
+}
+
+func newPathConstraint(path, re string) (verifier, error) {
+	var reCompiled *regexp.Regexp
+	if re != "" {
+		var err error
+		reCompiled, err = regexp.Compile(re)
+		if err != nil {
+			return nil, err
+		}
+	}
+	res := &pathConstraint{
+		path:   path,
+		regexp: reCompiled,
+	}
+	return res, nil
+}
+
+func (c *pathConstraint) Verify(r *http.Request) []error {
+	path := r.URL.Path
+	if c.path != "" && c.path != path {
+		return []error{fmt.Errorf("url path %s doesn't match expected %s", path, c.path)}
+	}
+	if c.regexp != nil && !c.regexp.MatchString(path) {
+		return []error{fmt.Errorf("url path %s doesn't match regexp %s", path, c.regexp)}
+	}
+	return nil
+}


### PR DESCRIPTION
```
         requestConstraints:
           - kind: pathMatches
             path: /api/v1/test/somekey
```
or
```
         requestConstraints:
           - kind: pathMatches
             regexp: ^/api/v1/test/.*$
```
If it's ok, I will add diff for documentation
