### PR TITLE
Fix windows warning during test run

### DIFF
--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -27,7 +27,7 @@ func NewServiceMock(serviceName string, mock *definition) *ServiceMock {
 }
 
 func (m *ServiceMock) StartServer() error {
-	addr := ":0" // all interfaces, random port
+	addr := "localhost:0" // loopback, random port
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
During test run I see warning from windows system, because gonkey create mock on each interface. I don't see any reason why local test require global address bind.

![image](https://user-images.githubusercontent.com/5764541/107562601-47964500-6b9d-11eb-85d5-24e8eeb5997c.png)
