### PR TITLE
new: add support for "Host" http header

### DIFF
--- a/runner/request.go
+++ b/runner/request.go
@@ -178,7 +178,11 @@ func request(test models.TestInterface, b *bytes.Buffer, host string) (*http.Req
 	}
 
 	for k, v := range test.Headers() {
-		req.Header.Add(k, v)
+		if strings.ToLower(k) == "host" {
+			req.Host = v
+		} else {
+			req.Header.Add(k, v)
+		}
 	}
 	return req, nil
 }


### PR DESCRIPTION
"Host" apparently a special header and if you just put it in "Headers", then go-lang simply ignores it and the "Host" will consists a real value. Therefore, it is necessary to process this headers differently.