### PR TITLE
new: support variables in mock definition

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -209,6 +209,9 @@ responseHeaders:
 - headers
 - request
 - response
+- body для моков
+- headers для моков
+- requestConstraints для моков
 
 Пример использования:
 
@@ -221,6 +224,14 @@ responseHeaders:
   request: '{"reqParam": "{{ $reqParam }}"}'
   response:
     200: "{{ $resp }}"
+  mocks:
+    server_mock:
+      strategy: constant
+      body: >
+        {
+          "message": "{{ $mockParam }}"
+        }
+      statusCode: 200
 ```
 
 Присваивать значения переменным можно следующими способами:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ You can use variables in the description of the test, the following fields are s
 - headers
 - request
 - response
+- mocks body
+- mocks headers
+- mocks requestConstraints
 
 Example:
 
@@ -224,6 +227,14 @@ Example:
   request: '{"reqParam": "{{ $reqParam }}"}'
   response:
     200: "{{ $resp }}"
+  mocks:
+    server_mock:
+      strategy: constant
+      body: >
+        {
+          "message": "{{ $mockParam }}"
+        }
+      statusCode: 200
 ```
 
 You can assign values to variables in the following ways (priorities are from top to bottom):

--- a/testloader/yaml_file/test_variables_test.go
+++ b/testloader/yaml_file/test_variables_test.go
@@ -101,4 +101,12 @@ func checkApplied(t *testing.T, test models.TestInterface) {
 	resp, ok = test.GetResponse(500)
 	assert.True(t, ok)
 	assert.Equal(t, "existingVar_Value - {{ $notExistingVar }}", resp)
+
+	raw, ok := test.ServiceMocks()["server"]
+	assert.True(t, ok)
+	mockMap, ok := raw.(map[interface{}]interface{})
+	assert.True(t, ok)
+	mockBody, ok := mockMap["body"]
+	assert.True(t, ok)
+	assert.Equal(t, "{\"reqParam\": \"reqParam_value\"}", mockBody)
 }

--- a/testloader/yaml_file/testdata/variables.yaml
+++ b/testloader/yaml_file/testdata/variables.yaml
@@ -19,3 +19,8 @@
     200: "{{ $resp }}"
     404: "{{ $respRx }}"
     500: "{{ $existingVar }} - {{ $notExistingVar }}"
+  mocks:
+    server:
+      strategy: constant
+      body: '{"reqParam": "{{ $reqParam }}"}'
+      statusCode: 200

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -56,6 +56,10 @@ func (vs *Variables) Apply(t models.TestInterface) models.TestInterface {
 		newTest.SetForm(vs.performForm(form))
 	}
 
+	for _, definition := range newTest.ServiceMocks() {
+		vs.performInterface(definition)
+	}
+
 	return newTest
 }
 
@@ -92,6 +96,27 @@ func (vs *Variables) perform(str string) string {
 	}
 
 	return str
+}
+
+func (vs *Variables) performInterface(value interface{}) {
+	if mapValue, ok := value.(map[interface{}]interface{}); ok {
+		for key := range mapValue {
+			if strValue, ok := mapValue[key].(string); ok {
+				mapValue[key] = vs.perform(strValue)
+			} else {
+				vs.performInterface(mapValue[key])
+			}
+		}
+	}
+	if arrValue, ok := value.([]interface{}); ok {
+		for idx := range arrValue {
+			if strValue, ok := arrValue[idx].(string); ok {
+				arrValue[idx] = vs.perform(strValue)
+			} else {
+				vs.performInterface(arrValue[idx])
+			}
+		}
+	}
 }
 
 func (vs *Variables) get(name string) *Variable {


### PR DESCRIPTION
Support variable's substitution in mock definition:
```
  mocks:
    server_mock:
      strategy: constant
      body: >
        {
          "message": "{{ $someVariable }}"
        }
      statusCode: 200
```