### PR TITLE
mocks file reply strategy: show error when no file found by filepath

### DIFF
--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -173,7 +173,7 @@ func (l *Loader) loadFileStrategy(path string, def map[interface{}]interface{}) 
 	if err != nil {
 		return nil, err
 	}
-	return newFileReplyWithCode(filename, statusCode, headers), nil
+	return newFileReplyWithCode(filename, statusCode, headers)
 }
 
 func (l *Loader) loadConstantStrategy(path string, def map[interface{}]interface{}) (replyStrategy, error) {

--- a/mocks/reply_strategy.go
+++ b/mocks/reply_strategy.go
@@ -34,14 +34,17 @@ func unhandledRequestError(r *http.Request) []error {
 	return []error{fmt.Errorf("unhandled request to mock:\n%s", requestContent)}
 }
 
-func newFileReplyWithCode(filename string, statusCode int, headers map[string]string) replyStrategy {
-	content, _ := ioutil.ReadFile(filename)
+func newFileReplyWithCode(filename string, statusCode int, headers map[string]string) (replyStrategy, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
 	r := &constantReply{
 		replyBody:  content,
 		statusCode: statusCode,
 		headers:    headers,
 	}
-	return r
+	return r, nil
 }
 
 func newConstantReplyWithCode(content []byte, statusCode int, headers map[string]string) replyStrategy {


### PR DESCRIPTION
Приведу пример теста:
```
- name: test name
  method: POST
  path: /some/path
  mocks:
    eventBus:
      calls: 1
      strategy: uriVary
      uris:
        /jsonrpc/v2/events.produce:
          calls: 1
          strategy: file

          # файла не существует по указанному пути
          filename: mocks/event-bus-success.json
```

Когда мок файла не существует по указанному пути, замоканный сервис при обращении к нему вернет клиентам пустое тело ответа с заголовком Content-Length: 0, что может привести к неожиданному поведению. 
При написании тестов можно допустить трудноуловимые опечатки в путях (нижнее подчеркивание вместо дефисов в имени файла, например). И фреймворк в текущей версии не подскажет о том, что мок-файла не существует.

С этой правкой, при запуске тестов в логе будет указано:
runner_testing.go:99: unable to load definition for eventBus: open mocks/event-bus-success.json: no such file or directory. 

Запускаемый тест зафейлится, давая тестировщику понять причину фейла.