### PR TITLE
doc: update Readme files - backslash in regexp should be escaped

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -172,7 +172,7 @@ responseHeaders:
     response:
         200: |
           {
-            "id": "$matchRegexp([\w-]+)",
+            "id": "$matchRegexp([\\w-]+)",
             "jsonrpc": "$matchRegexp([12].0)",
             "result": [
               "data": [

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The tests can be now ran with `go test`, for example: `go test ./...`.
         "result": {
           "user_id": {{ .userId }},
           "amount": {{ .amount }},
-          "token": "$matchRegexp(^\w{16}$)"
+          "token": "$matchRegexp(^\\w{16}$)"
         }
       }
 
@@ -175,7 +175,7 @@ or for elements of map/array (if it's JSON):
     response:
         200: |
           {
-            "id": "$matchRegexp([\w-]+)",
+            "id": "$matchRegexp([\\w-]+)",
             "jsonrpc": "$matchRegexp([12].0)",
             "result": [
               "data": [


### PR DESCRIPTION
If backslash is not escaped in json the sample from Readme would give an error like below during test execution:

```
... invalid JSON in response for test <test name>: invalid character ‘w’ in string escape code ...
```