### PR TITLE
(service_mock): set server address from argument

### DIFF
--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -39,7 +39,7 @@ func (m *Mocks) ResetDefinitions() {
 
 func (m *Mocks) Start() error {
 	for _, v := range m.mocks {
-		err := v.StartServer("localhost:0") // loopback, random port
+		err := v.StartServer()
 		if err != nil {
 			m.Shutdown()
 			return err

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -39,7 +39,7 @@ func (m *Mocks) ResetDefinitions() {
 
 func (m *Mocks) Start() error {
 	for _, v := range m.mocks {
-		err := v.StartServer()
+		err := v.StartServer("localhost:0") // loopback, random port
 		if err != nil {
 			m.Shutdown()
 			return err

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -28,6 +28,10 @@ func NewServiceMock(serviceName string, mock *definition) *ServiceMock {
 
 func (m *ServiceMock) StartServer() error {
 	addr := "localhost:0" // loopback, random port
+	return m.StartServerWithAddr(addr)
+}
+
+func (m *ServiceMock) StartServerWithAddr(addr string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -26,8 +26,7 @@ func NewServiceMock(serviceName string, mock *definition) *ServiceMock {
 	}
 }
 
-func (m *ServiceMock) StartServer() error {
-	addr := "localhost:0" // loopback, random port
+func (m *ServiceMock) StartServer(addr string) error {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -27,8 +27,7 @@ func NewServiceMock(serviceName string, mock *definition) *ServiceMock {
 }
 
 func (m *ServiceMock) StartServer() error {
-	addr := "localhost:0" // loopback, random port
-	return m.StartServerWithAddr(addr)
+	return m.StartServerWithAddr("localhost:0") // loopback, random port
 }
 
 func (m *ServiceMock) StartServerWithAddr(addr string) error {

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -26,7 +26,8 @@ func NewServiceMock(serviceName string, mock *definition) *ServiceMock {
 	}
 }
 
-func (m *ServiceMock) StartServer(addr string) error {
+func (m *ServiceMock) StartServer() error {
+	addr := "localhost:0" // loopback, random port
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
Привет, хотелось бы управлять адресом поднимаемого мок сервера через аргументы, тк в моем случае тестируемый сервис находится вне сервиса откуда запускаются тесты (другой контейнер) и поэтому мне нужно предопределить адрес мок сервера при старте тестируемого сервиса