### PR TITLE
added bodyMatchesText requestConstraint with example test

### DIFF
--- a/README-ru.md
+++ b/README-ru.md
@@ -785,6 +785,37 @@ runner.RunWithTesting(t, &runner.RunWithTestingParams{
     ...
 ```
 
+###### bodyMatchesText
+
+Проверяет что, тело запроса соответствует указанному или подпадает под условия регулярного выражения.
+
+Параметры:
+- `body` - строка, которой должно быть равно значение тела запроса;
+- `regexp` - регулярное выражение, которому должно соответствовать значение тела.
+
+Примеры:
+```yaml
+  ...
+  mocks:
+    service1:
+      requestConstraints:
+        - kind: bodyMatchesText
+            body: |-
+              query HeroNameAndFriends {
+                    hero {
+                      name
+                      friends {
+                        name
+                      }
+                    }
+                  }
+    service2:
+      requestConstraints:
+        - kind: bodyMatchesText
+            regexp: (HeroNameAndFriendsq)
+    ...
+```
+
 ###### bodyMatchesXML
 
 Проверяет, что тело запроса - это XML, который соответствует заданному в параметре `body`.

--- a/README.md
+++ b/README.md
@@ -785,6 +785,39 @@ Examples:
     ...
 ```
 
+###### bodyMatchesText
+
+Checks that the request has the defined body text, or it falls under the definition of a regular expression.
+
+Parameters:
+
+- `body` - a string with the expected request body value;
+- `regexp` - a regular expression to check the body value against.
+
+
+Examples:
+```yaml
+  ...
+  mocks:
+    service1:
+      requestConstraints:
+        - kind: bodyMatchesText
+            body: |-
+              query HeroNameAndFriends {
+                    hero {
+                      name
+                      friends {
+                        name
+                      }
+                    }
+                  }
+    service2:
+      requestConstraints:
+        - kind: bodyMatchesText
+            regexp: (HeroNameAndFriends)
+    ...
+```
+
 ###### bodyMatchesXML
 
 Checks that the request body is XML, and it matches to the XML defined in the `body` parameter.

--- a/examples/mock-body-matching/cases/do.yaml
+++ b/examples/mock-body-matching/cases/do.yaml
@@ -1,0 +1,45 @@
+- name: Test body matching
+  mocks:
+    backend:
+      strategy: uriVary
+      uris:
+        /process:
+          requestConstraints:
+            - kind: bodyMatchesText
+              # >- and |- remove the line feed, remove the trailing blank lines.
+              body: |-
+                query HeroNameAndFriends {
+                      hero {
+                        name
+                        friends {
+                          name
+                        }
+                      }
+                    }
+            - kind: bodyMatchesText
+              regexp: (HeroNameAndFriends)
+          strategy: constant
+          body: "OK"
+          statusCode: 200
+  method: POST
+  path: /do
+  response:
+    200: |
+      {
+                "data": {
+                  "hero": {
+                    "name": "R2-D2",
+                    "friends": [
+                      {
+                        "name": "Luke Skywalker"
+                      },
+                      {
+                        "name": "Han Solo"
+                      },
+                      {
+                        "name": "Leia Organa"
+                      }
+                    ]
+                  }
+                }
+              }

--- a/examples/mock-body-matching/func_test.go
+++ b/examples/mock-body-matching/func_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/lamoda/gonkey/mocks"
+	"github.com/lamoda/gonkey/runner"
+)
+
+func TestProxy(t *testing.T) {
+	m := mocks.NewNop("backend")
+	if err := m.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer m.Shutdown()
+
+	os.Setenv("BACKEND_ADDR", m.Service("backend").ServerAddr())
+	initServer()
+	srv := httptest.NewServer(nil)
+
+	runner.RunWithTesting(t, &runner.RunWithTestingParams{
+		Server:   srv,
+		TestsDir: "cases",
+		Mocks:    m,
+	})
+}

--- a/examples/mock-body-matching/main.go
+++ b/examples/mock-body-matching/main.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	initServer()
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func initServer() {
+	http.HandleFunc("/do", Do)
+}
+
+func Do(w http.ResponseWriter, r *http.Request) {
+	if err := BackendPost(); err != nil {
+		log.Print(err)
+		w.Write([]byte("{\"status\": \"error\"}"))
+		return
+	}
+
+	w.Header().Add("Content-Type", "application/json")
+	w.Write([]byte("{\n  \"data\": {\n    \"hero\": {\n      \"name\": \"R2-D2\",\n   " +
+		"   \"friends\": [\n        {\n          \"name\": \"Luke Skywalker\"\n        },\n        " +
+		"{\n          \"name\": \"Han Solo\"\n        },\n        {\n          \"name\": \"Leia Organa\"\n   " +
+		"     }\n      ]\n    }\n  }\n}"))
+}
+
+func BackendPost() error {
+	body := `query HeroNameAndFriends {
+      hero {
+        name
+        friends {
+          name
+        }
+      }
+    }`
+	url := fmt.Sprintf("http://%s/process", os.Getenv("BACKEND_ADDR"))
+	res, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("backend response status code %d", res.StatusCode)
+	}
+
+	return nil
+}

--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -284,6 +284,9 @@ func (l *Loader) loadConstraintOfKind(kind string, def map[interface{}]interface
 	case "headerIs":
 		*ak = append(*ak, "header", "value", "regexp")
 		return l.loadHeaderIsConstraint(def)
+	case "bodyMatchesText":
+		*ak = append(*ak, "body", "regexp")
+		return l.loadBodyMatchesTextConstraint(def)
 	case "pathMatches":
 		*ak = append(*ak, "path", "regexp")
 		return l.loadPathMatchesConstraint(def)
@@ -404,6 +407,23 @@ func (l *Loader) loadHeaderIsConstraint(def map[interface{}]interface{}) (verifi
 		}
 	}
 	return newHeaderConstraint(header, valueStr, regexpStr)
+}
+
+func (l *Loader) loadBodyMatchesTextConstraint(def map[interface{}]interface{}) (verifier, error) {
+	var bodyStr, regexpStr string
+	if path, ok := def["body"]; ok {
+		bodyStr, ok = path.(string)
+		if !ok {
+			return nil, errors.New("`path` must be string")
+		}
+	}
+	if regexp, ok := def["regexp"]; ok {
+		regexpStr, ok = regexp.(string)
+		if !ok || regexp == "" {
+			return nil, errors.New("`regexp` must be string")
+		}
+	}
+	return newBodyMatchesTextConstraint(bodyStr, regexpStr)
 }
 
 func validateMapKeys(m map[interface{}]interface{}, allowedKeys ...string) error {

--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -411,15 +411,15 @@ func (l *Loader) loadHeaderIsConstraint(def map[interface{}]interface{}) (verifi
 
 func (l *Loader) loadBodyMatchesTextConstraint(def map[interface{}]interface{}) (verifier, error) {
 	var bodyStr, regexpStr string
-	if path, ok := def["body"]; ok {
-		bodyStr, ok = path.(string)
+	if body, ok := def["body"]; ok {
+		bodyStr, ok = body.(string)
 		if !ok {
-			return nil, errors.New("`path` must be string")
+			return nil, errors.New("`body` must be string")
 		}
 	}
 	if regexp, ok := def["regexp"]; ok {
 		regexpStr, ok = regexp.(string)
-		if !ok || regexp == "" {
+		if !ok {
 			return nil, errors.New("`regexp` must be string")
 		}
 	}

--- a/mocks/request_constraint.go
+++ b/mocks/request_constraint.go
@@ -276,3 +276,47 @@ func (c *pathConstraint) Verify(r *http.Request) []error {
 	}
 	return nil
 }
+
+type bodyMatchesTextConstraint struct {
+	verifier
+
+	body   string
+	regexp *regexp.Regexp
+}
+
+func newBodyMatchesTextConstraint(body, re string) (verifier, error) {
+	var reCompiled *regexp.Regexp
+	if re != "" {
+		var err error
+		reCompiled, err = regexp.Compile(re)
+		if err != nil {
+			return nil, err
+		}
+	}
+	res := &bodyMatchesTextConstraint{
+		body:   body,
+		regexp: reCompiled,
+	}
+	return res, nil
+}
+
+func (c *bodyMatchesTextConstraint) Verify(r *http.Request) []error {
+	ioBody, err := ioutil.ReadAll(r.Body)
+
+	if err != nil {
+		return []error{err}
+	}
+
+	// write body for future reusing
+	r.Body = ioutil.NopCloser(bytes.NewReader(ioBody))
+
+	body := string(ioBody)
+
+	if c.body != "" && c.body != body {
+		return []error{fmt.Errorf("body value\n%s\ndoesn't match expected\n%s", body, c.body)}
+	}
+	if c.regexp != nil && !c.regexp.MatchString(body) {
+		return []error{fmt.Errorf("body value\n%s\ndoesn't match regexp %s", body, c.regexp)}
+	}
+	return nil
+}


### PR DESCRIPTION
This constrait checks that the request has the defined body text, or it falls under the definition of a regular expression.
Useful when you have to check some non-JSON or XML requests (i.e. GraphQL)
