### PR TITLE
new: add comparisonParams to BodyMatches for Json and XML

### DIFF
--- a/compare/compare.go
+++ b/compare/compare.go
@@ -9,9 +9,9 @@ import (
 )
 
 type CompareParams struct {
-	IgnoreValues         bool
-	IgnoreArraysOrdering bool
-	DisallowExtraFields  bool
+	IgnoreValues         bool `json:"ignoreValues" yaml:"ignoreValues"`
+	IgnoreArraysOrdering bool `json:"ignoreArraysOrdering" yaml:"ignoreArraysOrdering"`
+	DisallowExtraFields  bool `json:"disallowExtraFields" yaml:"disallowExtraFields"`
 	failFast             bool // End compare operation after first error
 }
 

--- a/mocks/loader.go
+++ b/mocks/loader.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+
+	"github.com/lamoda/gonkey/compare"
 )
 
 type Loader struct {
@@ -266,10 +268,10 @@ func (l *Loader) loadConstraintOfKind(kind string, def map[interface{}]interface
 	case "nop":
 		return &nopConstraint{}, nil
 	case "bodyMatchesJSON":
-		*ak = append(*ak, "body")
+		*ak = append(*ak, "body", "comparisonParams")
 		return l.loadBodyMatchesJSONConstraint(def)
 	case "bodyJSONFieldMatchesJSON":
-		*ak = append(*ak, "path", "value")
+		*ak = append(*ak, "path", "value", "comparisonParams")
 		return l.loadBodyJSONFieldMatchesJSONConstraint(def)
 	case "queryMatches":
 		*ak = append(*ak, "expectedQuery")
@@ -291,11 +293,51 @@ func (l *Loader) loadConstraintOfKind(kind string, def map[interface{}]interface
 		*ak = append(*ak, "path", "regexp")
 		return l.loadPathMatchesConstraint(def)
 	case "bodyMatchesXML":
-		*ak = append(*ak, "body")
+		*ak = append(*ak, "body", "comparisonParams")
 		return l.loadBodyMatchesXMLConstraint(def)
 	default:
 		return nil, fmt.Errorf("unknown constraint: %s", kind)
 	}
+}
+
+func readCompareParams(def map[interface{}]interface{}) (compare.CompareParams, error) {
+	params := compare.CompareParams{
+		IgnoreArraysOrdering: true,
+	}
+
+	p, ok := def["comparisonParams"]
+	if !ok {
+		return params, nil
+	}
+
+	values, ok := p.(map[interface{}]interface{})
+	if !ok {
+		return params, errors.New("`comparisonParams` can't be parsed")
+	}
+
+	mapping := map[string]*bool{
+		"ignoreValues":         &params.IgnoreValues,
+		"ignoreArraysOrdering": &params.IgnoreArraysOrdering,
+		"disallowExtraFields":  &params.DisallowExtraFields,
+	}
+
+	for key, val := range values {
+		skey, ok := key.(string)
+		if !ok {
+			return params, errors.New("`comparisonParams` has non-string key")
+		}
+
+		bval, ok := val.(bool)
+		if !ok {
+			return params, errors.New("`comparisonParams` has non-bool values")
+		}
+
+		if pbval, ok := mapping[skey]; ok {
+			*pbval = bval
+		}
+
+	}
+	return params, nil
 }
 
 func (l *Loader) loadBodyMatchesJSONConstraint(def map[interface{}]interface{}) (verifier, error) {
@@ -307,7 +349,13 @@ func (l *Loader) loadBodyMatchesJSONConstraint(def map[interface{}]interface{}) 
 	if !ok {
 		return nil, errors.New("`body` must be string")
 	}
-	return newBodyMatchesJSONConstraint(body)
+
+	params, err := readCompareParams(def)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBodyMatchesJSONConstraint(body, params)
 }
 
 func (l *Loader) loadBodyJSONFieldMatchesJSONConstraint(def map[interface{}]interface{}) (verifier, error) {
@@ -328,7 +376,13 @@ func (l *Loader) loadBodyJSONFieldMatchesJSONConstraint(def map[interface{}]inte
 	if !ok {
 		return nil, errors.New("`value` must be string")
 	}
-	return newBodyJSONFieldMatchesJSONConstraint(path, value)
+
+	params, err := readCompareParams(def)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBodyJSONFieldMatchesJSONConstraint(path, value, params)
 }
 
 func (l *Loader) loadBodyMatchesXMLConstraint(def map[interface{}]interface{}) (verifier, error) {
@@ -340,7 +394,13 @@ func (l *Loader) loadBodyMatchesXMLConstraint(def map[interface{}]interface{}) (
 	if !ok {
 		return nil, errors.New("`body` must be string")
 	}
-	return newBodyMatchesXMLConstraint(body)
+
+	params, err := readCompareParams(def)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBodyMatchesXMLConstraint(body, params)
 }
 
 func (l *Loader) loadPathMatchesConstraint(def map[interface{}]interface{}) (verifier, error) {

--- a/mocks/request_constraint.go
+++ b/mocks/request_constraint.go
@@ -32,9 +32,10 @@ func (c *nopConstraint) Verify(r *http.Request) []error {
 
 type bodyMatchesXMLConstraint struct {
 	expectedBody interface{}
+	compareParams compare.CompareParams
 }
 
-func newBodyMatchesXMLConstraint(expected string) (verifier, error) {
+func newBodyMatchesXMLConstraint(expected string, params compare.CompareParams) (verifier, error) {
 	expectedBody, err := xmlparsing.Parse(expected)
 	if err != nil {
 		return nil, err
@@ -42,6 +43,7 @@ func newBodyMatchesXMLConstraint(expected string) (verifier, error) {
 
 	res := &bodyMatchesXMLConstraint{
 		expectedBody: expectedBody,
+		compareParams: params,
 	}
 	return res, nil
 }
@@ -62,19 +64,17 @@ func (c *bodyMatchesXMLConstraint) Verify(r *http.Request) []error {
 		return []error{err}
 	}
 
-	params := compare.CompareParams{
-		IgnoreArraysOrdering: true,
-	}
-	return compare.Compare(c.expectedBody, actual, params)
+	return compare.Compare(c.expectedBody, actual, c.compareParams)
 }
 
 type bodyMatchesJSONConstraint struct {
 	verifier
 
 	expectedBody interface{}
+	compareParams compare.CompareParams
 }
 
-func newBodyMatchesJSONConstraint(expected string) (verifier, error) {
+func newBodyMatchesJSONConstraint(expected string, params compare.CompareParams) (verifier, error) {
 	var expectedBody interface{}
 	err := json.Unmarshal([]byte(expected), &expectedBody)
 	if err != nil {
@@ -82,6 +82,7 @@ func newBodyMatchesJSONConstraint(expected string) (verifier, error) {
 	}
 	res := &bodyMatchesJSONConstraint{
 		expectedBody: expectedBody,
+		compareParams: params,
 	}
 	return res, nil
 }
@@ -101,18 +102,16 @@ func (c *bodyMatchesJSONConstraint) Verify(r *http.Request) []error {
 	if err != nil {
 		return []error{err}
 	}
-	params := compare.CompareParams{
-		IgnoreArraysOrdering: true,
-	}
-	return compare.Compare(c.expectedBody, actual, params)
+	return compare.Compare(c.expectedBody, actual, c.compareParams)
 }
 
 type bodyJSONFieldMatchesJSONConstraint struct {
 	path     string
 	expected interface{}
+	compareParams compare.CompareParams
 }
 
-func newBodyJSONFieldMatchesJSONConstraint(path, expected string) (verifier, error) {
+func newBodyJSONFieldMatchesJSONConstraint(path, expected string, params compare.CompareParams) (verifier, error) {
 	var v interface{}
 	err := json.Unmarshal([]byte(expected), &v)
 	if err != nil {
@@ -121,6 +120,7 @@ func newBodyJSONFieldMatchesJSONConstraint(path, expected string) (verifier, err
 	res := &bodyJSONFieldMatchesJSONConstraint{
 		path:     path,
 		expected: v,
+		compareParams: params,
 	}
 	return res, nil
 }
@@ -147,10 +147,7 @@ func (c *bodyJSONFieldMatchesJSONConstraint) Verify(r *http.Request) []error {
 	if err != nil {
 		return []error{err}
 	}
-	params := compare.CompareParams{
-		IgnoreArraysOrdering: true,
-	}
-	return compare.Compare(c.expected, actual, params)
+	return compare.Compare(c.expected, actual, c.compareParams)
 }
 
 type methodConstraint struct {

--- a/testloader/yaml_file/test_definition.go
+++ b/testloader/yaml_file/test_definition.go
@@ -1,6 +1,9 @@
 package yaml_file
 
-import "github.com/lamoda/gonkey/models"
+import (
+	"github.com/lamoda/gonkey/compare"
+	"github.com/lamoda/gonkey/models"
+)
 
 type TestDefinition struct {
 	Name                     string                    `json:"name" yaml:"name"`
@@ -19,7 +22,7 @@ type TestDefinition struct {
 	HeadersVal               map[string]string         `json:"headers" yaml:"headers"`
 	CookiesVal               map[string]string         `json:"cookies" yaml:"cookies"`
 	Cases                    []CaseData                `json:"cases" yaml:"cases"`
-	ComparisonParams         comparisonParams          `json:"comparisonParams" yaml:"comparisonParams"`
+	ComparisonParams         compare.CompareParams     `json:"comparisonParams" yaml:"comparisonParams"`
 	FixtureFiles             []string                  `json:"fixtures" yaml:"fixtures"`
 	MocksDefinition          map[string]interface{}    `json:"mocks" yaml:"mocks"`
 	PauseValue               int                       `json:"pause" yaml:"pause"`
@@ -35,12 +38,6 @@ type CaseData struct {
 	DbQueryArgs            map[string]interface{}         `json:"dbQueryArgs" yaml:"dbQueryArgs"`
 	DbResponseArgs         map[string]interface{}         `json:"dbResponseArgs" yaml:"dbResponseArgs"`
 	DbResponse             []string                       `json:"dbResponse" yaml:"dbResponse"`
-}
-
-type comparisonParams struct {
-	IgnoreValues         bool `json:"ignoreValues" yaml:"ignoreValues"`
-	IgnoreArraysOrdering bool `json:"ignoreArraysOrdering" yaml:"ignoreArraysOrdering"`
-	DisallowExtraFields  bool `json:"disallowExtraFields" yaml:"disallowExtraFields"`
 }
 
 type scriptParams struct {


### PR DESCRIPTION
```
            - kind: bodyMatchesJSON
              comparisonParams:
                disallowExtraFields: true
              body: >
                {
                  "some_field": "some_value"
                }
```