### PR TITLE
fix: fix "undefined variable" error if test consist "case" and "{{ $v…

### DIFF
--- a/testloader/yaml_file/parser.go
+++ b/testloader/yaml_file/parser.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"strings"
 	"text/template"
 
 	"gopkg.in/yaml.v2"
@@ -35,7 +36,18 @@ func parseTestDefinitionFile(absPath string) ([]Test, error) {
 	return tests, nil
 }
 
+const (
+	variableToProtect1 = "{{$"
+	gonkeyReplacement1 = "!gonkey_protect_var1!$"
+
+	variableToProtect2 = "{{ $"
+	gonkeyReplacement2 = "!gonkey_protect_var2!$"
+)
+
 func substituteArgs(tmpl string, args map[string]interface{}) (string, error) {
+	tmpl = strings.ReplaceAll(tmpl, variableToProtect1, gonkeyReplacement1)
+	tmpl = strings.ReplaceAll(tmpl, variableToProtect2, gonkeyReplacement2)
+
 	compiledTmpl, err := template.New("").Parse(tmpl)
 	if err != nil {
 		return "", err
@@ -47,7 +59,9 @@ func substituteArgs(tmpl string, args map[string]interface{}) (string, error) {
 		return "", err
 	}
 
-	return buf.String(), nil
+	tmpl = strings.ReplaceAll(buf.String(), gonkeyReplacement1, variableToProtect1)
+	tmpl = strings.ReplaceAll(tmpl, gonkeyReplacement2, variableToProtect2)
+	return tmpl, nil
 }
 
 func substituteArgsToMap(tmpl map[string]string, args map[string]interface{}) (map[string]string, error) {


### PR DESCRIPTION
Fix  template parse error ("undefined variable") if test consist
1) "case" section 
2) and any "{{ $variable }}"

For example like this:
```
- name: Test name
  method: POST
  path: /api/service/v1/endpoint
  headers:
    Authorization: "Bearer {{ $jwt }}"
  request: >
    {
      "field1": "{{ .value1 }}",
      "field2": "{{ .value2 }}",
    }
  response:
    400: >
      {"code":"BadRequestError"}
  cases:
    - requestArgs:
        value1: "non-empty"
        value2: "non-empty"
    - requestArgs:
        value1: ""
        value2: "non-empty"
```