### PR TITLE
#187 Wrap test in subtest for go test runner

### DIFF
--- a/output/testing/testing.go
+++ b/output/testing/testing.go
@@ -2,20 +2,16 @@ package testing
 
 import (
 	"bytes"
-	"testing"
+	"fmt"
 	"text/template"
 
 	"github.com/lamoda/gonkey/models"
 )
 
-type TestingOutput struct {
-	testing *testing.T
-}
+type TestingOutput struct{}
 
-func NewOutput(t *testing.T) *TestingOutput {
-	return &TestingOutput{
-		testing: t,
-	}
+func NewOutput() *TestingOutput {
+	return &TestingOutput{}
 }
 
 func (o *TestingOutput) Process(t models.TestInterface, result *models.Result) error {
@@ -24,7 +20,7 @@ func (o *TestingOutput) Process(t models.TestInterface, result *models.Result) e
 		if err != nil {
 			return err
 		}
-		o.testing.Error(text)
+		fmt.Println(text)
 	}
 	return nil
 }

--- a/runner/console_handler.go
+++ b/runner/console_handler.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"errors"
+
+	"github.com/lamoda/gonkey/models"
+)
+
+type ConsoleHandler struct {
+	totalTests   int
+	failedTests  int
+	skippedTests int
+	brokenTests  int
+}
+
+func NewConsoleHandler() *ConsoleHandler {
+	return &ConsoleHandler{}
+}
+
+func (h *ConsoleHandler) HandleTest(test models.TestInterface, executeTest testExecutor) error {
+	testResult, err := executeTest(test)
+	switch {
+	case err != nil && errors.Is(err, errTestSkipped):
+		h.skippedTests++
+	case err != nil && errors.Is(err, errTestBroken):
+		h.brokenTests++
+	case err != nil:
+		return err
+	}
+
+	h.totalTests++
+	if !testResult.Passed() {
+		h.failedTests++
+	}
+
+	return nil
+}
+
+func (h *ConsoleHandler) Summary() *models.Summary {
+	return &models.Summary{
+		Success: h.failedTests == 0,
+		Skipped: h.skippedTests,
+		Broken:  h.brokenTests,
+		Failed:  h.failedTests,
+		Total:   h.totalTests,
+	}
+}

--- a/runner/console_handler_test.go
+++ b/runner/console_handler_test.go
@@ -1,0 +1,97 @@
+package runner
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lamoda/gonkey/models"
+)
+
+func TestConsoleHandler_HandleTest_Summary(t *testing.T) {
+	type result struct {
+		result *models.Result
+		err    error
+	}
+	tests := []struct {
+		name            string
+		testExecResults []result
+		wantErr         bool
+		expectedSummary *models.Summary
+	}{
+		{
+			name:            "1 successful test",
+			testExecResults: []result{{result: &models.Result{Errors: nil}}},
+			expectedSummary: &models.Summary{
+				Success: true,
+				Failed:  0,
+				Total:   1,
+			},
+		},
+		{
+			name: "1 successful test, 1 broken test",
+			testExecResults: []result{
+				{result: &models.Result{}, err: nil},
+				{result: &models.Result{}, err: errTestBroken},
+			},
+			expectedSummary: &models.Summary{
+				Success: true,
+				Failed:  0,
+				Broken:  1,
+				Total:   2,
+			},
+		},
+		{
+			name: "1 successful test, 1 skipped test",
+			testExecResults: []result{
+				{result: &models.Result{}, err: nil},
+				{result: &models.Result{}, err: errTestSkipped},
+			},
+			expectedSummary: &models.Summary{
+				Success: true,
+				Skipped: 1,
+				Total:   2,
+			},
+		},
+		{
+			name: "1 successful test, 1 failed test",
+			testExecResults: []result{
+				{result: &models.Result{}, err: nil},
+				{result: &models.Result{Errors: []error{errors.New("some err")}}, err: nil},
+			},
+			expectedSummary: &models.Summary{
+				Success: false,
+				Failed:  1,
+				Total:   2,
+			},
+		},
+		{
+			name: "test with unexpected error",
+			testExecResults: []result{
+				{result: &models.Result{}, err: errors.New("unexpected error")},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := NewConsoleHandler()
+
+			for _, execResult := range tt.testExecResults {
+				executor := func(models.TestInterface) (*models.Result, error) {
+					return execResult.result, execResult.err
+				}
+				err := h.HandleTest(nil, executor)
+				if tt.wantErr {
+					require.Error(t, err)
+					return
+				}
+
+				require.NoError(t, err)
+			}
+
+			require.Equal(t, tt.expectedSummary, h.Summary())
+		})
+	}
+}

--- a/runner/request.go
+++ b/runner/request.go
@@ -16,16 +16,10 @@ import (
 	"github.com/lamoda/gonkey/models"
 )
 
-func newClient() (*http.Client, error) {
+func newClient(proxyURL *url.URL) *http.Client {
 	transport := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	if os.Getenv("HTTP_PROXY") != "" {
-		proxyUrl, err := url.Parse(os.Getenv("HTTP_PROXY"))
-		if err != nil {
-			return nil, err
-		}
-		transport.Proxy = http.ProxyURL(proxyUrl)
+		Proxy:           http.ProxyURL(proxyURL),
 	}
 
 	return &http.Client{
@@ -33,7 +27,7 @@ func newClient() (*http.Client, error) {
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
-	}, nil
+	}
 }
 
 func newRequest(host string, test models.TestInterface) (req *http.Request, err error) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -24,20 +25,28 @@ type Config struct {
 	Mocks          *mocks.Mocks
 	MocksLoader    *mocks.Loader
 	Variables      *variables.Variables
+	HttpProxyURL   *url.URL
 }
 
+type testExecutor func(models.TestInterface) (*models.Result, error)
+type testHandler func(models.TestInterface, testExecutor) error
+
 type Runner struct {
-	loader   testloader.LoaderInterface
-	output   []output.OutputInterface
-	checkers []checker.CheckerInterface
+	loader               testloader.LoaderInterface
+	testExecutionHandler testHandler
+	output               []output.OutputInterface
+	checkers             []checker.CheckerInterface
+	client               *http.Client
 
 	config *Config
 }
 
-func New(config *Config, loader testloader.LoaderInterface) *Runner {
+func New(config *Config, loader testloader.LoaderInterface, handler testHandler) *Runner {
 	return &Runner{
-		config: config,
-		loader: loader,
+		config:               config,
+		loader:               loader,
+		testExecutionHandler: handler,
+		client:               newClient(config.HttpProxyURL),
 	}
 }
 
@@ -49,83 +58,47 @@ func (r *Runner) AddCheckers(c ...checker.CheckerInterface) {
 	r.checkers = append(r.checkers, c...)
 }
 
-func (r *Runner) Run() (*models.Summary, error) {
-	if r.loader == nil {
-		s := &models.Summary{
-			Success: true,
-			Failed:  0,
-			Total:   0,
-		}
-		return s, nil
-	}
-
-	loader, err := r.loader.Load()
+func (r *Runner) Run() error {
+	tests, err := r.loader.Load()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	tests := []models.TestInterface{}
-	hasFocused := false
-	for test := range loader {
-		tests = append(tests, test)
-		if test.GetStatus() == "focus" {
-			hasFocused = true
-		}
-	}
-
-	client, err := newClient()
-	if err != nil {
-		return nil, err
-	}
-
-	totalTests := 0
-	failedTests := 0
-	skippedTests := 0
-	brokenTests := 0
-
-	for _, v := range tests {
+	hasFocused := checkHasFocused(tests)
+	for _, t := range tests {
+		test := t
 		if hasFocused {
-			switch v.GetStatus() {
+			switch test.GetStatus() {
 			case "focus":
-				v.SetStatus("")
+				test.SetStatus("")
 			case "broken":
 				// do nothing
 			default:
-				v.SetStatus("skipped")
+				test.SetStatus("skipped")
 			}
 		}
 
-		testResult, err := r.executeTest(v, client)
-		switch {
-		case err != nil && errors.Is(err, errTestSkipped):
-			skippedTests++
-		case err != nil && errors.Is(err, errTestBroken):
-			brokenTests++
-		case err != nil:
-			// todo: populate error with test name. Currently it is not possible here to get test name.
-			return nil, err
-		}
-
-		totalTests++
-		if len(testResult.Errors) > 0 {
-			failedTests++
-		}
-		for _, o := range r.output {
-			if err := o.Process(v, testResult); err != nil {
+		testExecutor := func(testInterface models.TestInterface) (*models.Result, error) {
+			testResult, err := r.executeTest(test)
+			if err != nil {
 				return nil, err
 			}
+
+			for _, o := range r.output {
+				if err := o.Process(test, testResult); err != nil {
+					return nil, err
+				}
+			}
+			return testResult, nil
 		}
+		err := r.testExecutionHandler(test, testExecutor)
+		if err != nil {
+			return fmt.Errorf("test %s error: %s", test.GetName(), err)
+		}
+
 	}
 
-	s := &models.Summary{
-		Success: failedTests == 0,
-		Skipped: skippedTests,
-		Broken:  brokenTests,
-		Failed:  failedTests,
-		Total:   totalTests,
-	}
-
-	return s, nil
+	return nil
 }
 
 var (
@@ -133,7 +106,7 @@ var (
 	errTestBroken  = errors.New("test was broken")
 )
 
-func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*models.Result, error) {
+func (r *Runner) executeTest(v models.TestInterface) (*models.Result, error) {
 
 	if v.GetStatus() != "" {
 		if v.GetStatus() == "broken" {
@@ -188,7 +161,7 @@ func (r *Runner) executeTest(v models.TestInterface, client *http.Client) (*mode
 		return nil, err
 	}
 
-	resp, err := client.Do(req)
+	resp, err := r.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -266,4 +239,13 @@ func (r *Runner) setVariablesFromResponse(t models.TestInterface, contentType, b
 	r.config.Variables.Merge(vars)
 
 	return nil
+}
+
+func checkHasFocused(tests []models.TestInterface) bool {
+	for _, test := range tests {
+		if test.GetStatus() == "focus" {
+			return true
+		}
+	}
+	return false
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -66,6 +66,8 @@ func (r *Runner) Run() error {
 
 	hasFocused := checkHasFocused(tests)
 	for _, t := range tests {
+		// make a copy because go test runner runs tests in separate goroutines
+		// and without copy tests will override each other
 		test := t
 		if hasFocused {
 			switch test.GetStatus() {

--- a/testloader/loader.go
+++ b/testloader/loader.go
@@ -5,5 +5,5 @@ import (
 )
 
 type LoaderInterface interface {
-	Load() (chan models.TestInterface, error)
+	Load() ([]models.TestInterface, error)
 }

--- a/testloader/yaml_file/yaml_file.go
+++ b/testloader/yaml_file/yaml_file.go
@@ -19,19 +19,18 @@ func NewLoader(testsLocation string) *YamlFileLoader {
 	}
 }
 
-func (l *YamlFileLoader) Load() (chan models.TestInterface, error) {
+func (l *YamlFileLoader) Load() ([]models.TestInterface, error) {
 	fileTests, err := l.parseTestsWithCases(l.testsLocation)
 	if err != nil {
 		return nil, err
 	}
-	ch := make(chan models.TestInterface)
-	go func() {
-		for i := range fileTests {
-			ch <- &fileTests[i]
-		}
-		close(ch)
-	}()
-	return ch, nil
+
+	ret := make([]models.TestInterface, len(fileTests))
+	for i, test := range fileTests {
+		test := test
+		ret[i] = &test
+	}
+	return ret, nil
 }
 
 func (l *YamlFileLoader) SetFileFilter(f string) {


### PR DESCRIPTION
Добавлено оборачивание каждого теста из .yaml файла в сабтест при запуске тестов через go test.
https://user-images.githubusercontent.com/16325204/196138717-e77d0f49-b4c2-49e3-a3b0-d4155aeef7b2.mov

Для корректной работы пришлось довольно сильно переделать исполнение теста в runner т.к. фактическое исполнение теста от начала до конца (включая вывод результатов) должен находиться внутри t.Run().

Код запуска теста стал чуть более сложным, но за счет разделения удалось унести код нужный только для запуска тестов через бинарь gonkey в console_runner.

После оборачивания тестов в t.Run() появился ещё один бонус. Теперь можно запускать конкретные gonkey-тесты через флаг `-run`. Например `go test gonkey_test.go -v -test.run "^\QTestSubscriptions/6."` запустит все тесты название которых начинается на `6.`.
https://user-images.githubusercontent.com/16325204/196148790-cf54bb68-ca11-480e-a8ce-10ec3ee2cfa6.mov