### PR TITLE
new: support of trailer headers

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -190,6 +190,10 @@ func (r *Runner) executeTest(v models.TestInterface) (*models.Result, error) {
 		Test:                v,
 	}
 
+	for name, value := range resp.Trailer {
+		result.ResponseHeaders["Trailer-"+name] = value
+	}
+
 	// launch script in cmd interface
 	if v.AfterRequestScriptPath() != "" {
 		if err := cmd_runner.CmdRun(v.AfterRequestScriptPath(), v.AfterRequestScriptTimeout()); err != nil {


### PR DESCRIPTION
Support for Trailer headers: 
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Trailer
https://pkg.go.dev/net/http#Response

This is rarely used feature, so I added this header to "ResponseHeaders" with prefix.