### PR TITLE
Added xml response body matching (re-used xml parser from constraints)

### DIFF
--- a/checker/response_body/response_body.go
+++ b/checker/response_body/response_body.go
@@ -25,20 +25,20 @@ func (c *ResponseBodyChecker) Check(t models.TestInterface, result *models.Resul
 	if expectedBody, ok := t.GetResponse(result.ResponseStatusCode); ok {
 		foundResponse = true
 		// is the response JSON document?
-		if strings.Contains(result.ResponseContentType, "json") && expectedBody != "" {
+		switch {
+		case strings.Contains(result.ResponseContentType, "json") && expectedBody != "":
 			checkErrs, err := compareJsonBody(t, expectedBody, result)
 			if err != nil {
 				return nil, err
 			}
 			errs = append(errs, checkErrs...)
-		} else if strings.Contains(result.ResponseContentType, "xml") && expectedBody != "" {
+		case strings.Contains(result.ResponseContentType, "xml") && expectedBody != "":
 			checkErrs, err := compareXmlBody(t, expectedBody, result)
 			if err != nil {
 				return nil, err
 			}
 			errs = append(errs, checkErrs...)
-		} else {
-			// compare bodies as leaf nodes
+		default:
 			errs = append(errs, compare.Compare(expectedBody, result.ResponseBody, compare.Params{})...)
 		}
 

--- a/checker/response_body/response_body.go
+++ b/checker/response_body/response_body.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lamoda/gonkey/checker"
 	"github.com/lamoda/gonkey/compare"
 	"github.com/lamoda/gonkey/models"
+	"github.com/lamoda/gonkey/xmlparsing"
 )
 
 type ResponseBodyChecker struct{}
@@ -31,8 +32,16 @@ func (c *ResponseBodyChecker) Check(t models.TestInterface, result *models.Resul
 			}
 			errs = append(errs, checkErrs...)
 		} else {
-			// compare bodies as leaf nodes
-			errs = append(errs, compare.Compare(expectedBody, result.ResponseBody, compare.Params{})...)
+			if strings.Contains(result.ResponseContentType, "xml") && expectedBody != "" {
+				checkErrs, err := compareXmlBody(t, expectedBody, result)
+				if err != nil {
+					return nil, err
+				}
+				errs = append(errs, checkErrs...)
+			} else {
+				// compare bodies as leaf nodes
+				errs = append(errs, compare.Compare(expectedBody, result.ResponseBody, compare.Params{})...)
+			}
 		}
 	}
 	if !foundResponse {
@@ -61,6 +70,32 @@ func compareJsonBody(t models.TestInterface, expectedBody string, result *models
 		return []error{errors.New("could not parse response")}, nil
 	}
 
+	params := compare.Params{
+		IgnoreValues:         !t.NeedsCheckingValues(),
+		IgnoreArraysOrdering: t.IgnoreArraysOrdering(),
+		DisallowExtraFields:  t.DisallowExtraFields(),
+	}
+
+	return compare.Compare(expected, actual, params), nil
+}
+
+func compareXmlBody(t models.TestInterface, expectedBody string, result *models.Result) ([]error, error) {
+	// decode expected body
+	expected, err := xmlparsing.Parse(expectedBody)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid XML in response for test %s (status %d): %s",
+			t.GetName(),
+			result.ResponseStatusCode,
+			err.Error(),
+		)
+	}
+
+	// decode actual body
+	actual, err := xmlparsing.Parse(result.ResponseBody)
+	if err != nil {
+		return []error{errors.New("could not parse response")}, nil
+	}
 	params := compare.Params{
 		IgnoreValues:         !t.NeedsCheckingValues(),
 		IgnoreArraysOrdering: t.IgnoreArraysOrdering(),

--- a/checker/response_body/response_body.go
+++ b/checker/response_body/response_body.go
@@ -31,18 +31,17 @@ func (c *ResponseBodyChecker) Check(t models.TestInterface, result *models.Resul
 				return nil, err
 			}
 			errs = append(errs, checkErrs...)
-		} else {
-			if strings.Contains(result.ResponseContentType, "xml") && expectedBody != "" {
-				checkErrs, err := compareXmlBody(t, expectedBody, result)
-				if err != nil {
-					return nil, err
-				}
-				errs = append(errs, checkErrs...)
-			} else {
-				// compare bodies as leaf nodes
-				errs = append(errs, compare.Compare(expectedBody, result.ResponseBody, compare.Params{})...)
+		} else if strings.Contains(result.ResponseContentType, "xml") && expectedBody != "" {
+			checkErrs, err := compareXmlBody(t, expectedBody, result)
+			if err != nil {
+				return nil, err
 			}
+			errs = append(errs, checkErrs...)
+		} else {
+			// compare bodies as leaf nodes
+			errs = append(errs, compare.Compare(expectedBody, result.ResponseBody, compare.Params{})...)
 		}
+
 	}
 	if !foundResponse {
 		err := fmt.Errorf("server responded with status %d", result.ResponseStatusCode)

--- a/examples/xml-body-matching/cases/do.yaml
+++ b/examples/xml-body-matching/cases/do.yaml
@@ -1,0 +1,12 @@
+- name: Test XML body matching
+  method: POST
+  path: /do
+  response:
+    200: >-
+      <?xml version="1.0" encoding="UTF-8"?>
+      <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+      xmlns:ns1="http://app.example.com">
+      <SOAP-ENV:Body>
+      <ns1:notifyResponse/>
+      </SOAP-ENV:Body>
+      </SOAP-ENV:Envelope>

--- a/examples/xml-body-matching/func_test.go
+++ b/examples/xml-body-matching/func_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/lamoda/gonkey/runner"
+)
+
+func TestProxy(t *testing.T) {
+
+	initServer()
+	srv := httptest.NewServer(nil)
+
+	runner.RunWithTesting(t, &runner.RunWithTestingParams{
+		Server:   srv,
+		TestsDir: "cases",
+	})
+}

--- a/examples/xml-body-matching/main.go
+++ b/examples/xml-body-matching/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+	"net/http"
+)
+
+func main() {
+	initServer()
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func initServer() {
+	http.HandleFunc("/do", Do)
+}
+
+func Do(w http.ResponseWriter, _ *http.Request) {
+
+	w.Header().Add("Content-Type", "application/xml")
+	_, err := w.Write([]byte("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n      " +
+		"<SOAP-ENV:Envelope xmlns:SOAP-ENV=\"http://schemas.xmlsoap.org/soap/envelope/\"\r\n" +
+		"                         xmlns:ns1=\"http://app.example.com\">\r\n" +
+		"      \t<SOAP-ENV:Body>\r\n      \t\t<ns1:notifyResponse/>\r\n      " +
+		"\t</SOAP-ENV:Body>\r\n      </SOAP-ENV:Envelope>"))
+	if err != nil {
+		return
+	}
+}


### PR DESCRIPTION
It turns out that in gonkey xml in response is checked as plain text.
Despite the fact that in request constraints xml is parsed.
This PR fixes this problem.

Оказывается в gonkey xml в response проверяется как обычный текст. 
Несмотря на то, что в request constraints xml парсится. 
Этот ПР исправляет данную проблему. 