### PR TITLE
runner: support testing/synctest in RunWithTesting helpers

### DIFF
--- a/runner/request.go
+++ b/runner/request.go
@@ -18,9 +18,11 @@ import (
 )
 
 func newClient(proxyURL *url.URL) *http.Client {
+	// Idle keep-alive readLoops block testing/synctest bubble exit on real I/O.
 	transport := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Client is only used for testing.
-		Proxy:           http.ProxyURL(proxyURL),
+		TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // Client is only used for testing.
+		Proxy:             http.ProxyURL(proxyURL),
+		DisableKeepAlives: true,
 	}
 
 	return &http.Client{

--- a/runner/runner_multidb.go
+++ b/runner/runner_multidb.go
@@ -39,6 +39,9 @@ type RunWithMultiDbParams struct {
 	OutputFunc    output.OutputInterface
 	Checkers      []checker.CheckerInterface
 	FixtureLoader fixtures.LoaderMultiDb
+
+	// NoSubtests skips the per-case t.Run wrapper. Required inside testing/synctest.Test.
+	NoSubtests bool
 }
 
 // RunWithMultiDb is a helper function the wraps the common Run and provides simple way
@@ -87,7 +90,7 @@ func RunWithMultiDb(t *testing.T, params *RunWithMultiDbParams) {
 	yamlLoader := yaml_file.NewLoader(params.TestsDir)
 	yamlLoader.SetFileFilter(os.Getenv("GONKEY_FILE_FILTER"))
 
-	handler := testingHandler{t}
+	handler := testingHandler{t: t, noSubtests: params.NoSubtests}
 	runner := New(
 		&Config{
 			Host:                  params.Server.URL,

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -46,6 +46,10 @@ type RunWithTestingParams struct {
 	OutputFunc    output.OutputInterface
 	Checkers      []checker.CheckerInterface
 	FixtureLoader fixtures.Loader
+
+	// NoSubtests skips the per-case t.Run wrapper. Required inside testing/synctest.Test.
+	NoSubtests bool
+
 	// TestIT labels: can be overridden by test-level labels
 	AllurePackage   string
 	AllureTestClass string
@@ -144,7 +148,7 @@ func initRunner(
 	yamlLoader := yaml_file.NewLoader(params.TestsDir)
 	yamlLoader.SetFileFilter(os.Getenv("GONKEY_FILE_FILTER"))
 
-	handler := testingHandler{t}
+	handler := testingHandler{t: t, noSubtests: params.NoSubtests}
 	runner := New(
 		&Config{
 			Host:           params.Server.URL,
@@ -173,26 +177,38 @@ func addCheckers(runner *Runner, params *RunWithTestingParams) {
 }
 
 type testingHandler struct {
-	t *testing.T
+	t          *testing.T
+	noSubtests bool
 }
 
 func (h testingHandler) HandleTest(test models.TestInterface, executeTest testExecutor) error {
 	var returnErr error
-	h.t.Run(test.GetName(), func(t *testing.T) {
+	runCase := func(t *testing.T) {
 		result, err := executeTest(test)
 		if err != nil {
 			if errors.Is(err, errTestSkipped) || errors.Is(err, errTestBroken) {
 				t.Skip()
-			} else {
-				returnErr = err
-				t.Fatal(err)
+
+				return
 			}
+			returnErr = err
+			t.Fatal(err)
+
+			return
 		}
 
 		if !result.Passed() {
 			t.Fail()
 		}
-	})
+	}
+
+	if h.noSubtests {
+		runCase(h.t)
+
+		return returnErr
+	}
+
+	h.t.Run(test.GetName(), runCase)
 
 	return returnErr
 }


### PR DESCRIPTION
Adds a `NoSubtests` flag to `RunWithTestingParams` / `RunWithMultiDbParams`. When set, gonkey runs YAML cases inline on the parent `*testing.T` instead of wrapping each in `t.Run` — Go 1.26's `testing/synctest.Test` panics on `t.Run` inside a bubble.

Also enables `DisableKeepAlives` on the testing HTTP transport: idle keep-alive readLoops block synctest bubble exit because real network I/O is not durably blocking (observed as multi-minute hangs).

Default behavior is unchanged when the flag is not set. Backport of #317 to the v1 branch.