### PR TITLE
feat(fixtures/postgres): opt-in WithDeleteReset (DELETE instead of TRUNCATE)

### DIFF
--- a/fixtures/postgres/postgres.go
+++ b/fixtures/postgres/postgres.go
@@ -15,9 +15,10 @@ import (
 )
 
 type LoaderPostgres struct {
-	db       *sql.DB
-	location string
-	debug    bool
+	db              *sql.DB
+	location        string
+	debug           bool
+	resetWithDelete bool
 }
 
 type row map[string]interface{}
@@ -67,12 +68,35 @@ type loadContext struct {
 	refsInserted   rowsDict
 }
 
-func New(db *sql.DB, location string, debug bool) *LoaderPostgres {
-	return &LoaderPostgres{
+// Option configures optional LoaderPostgres behaviour.
+type Option func(*LoaderPostgres)
+
+// WithDeleteReset makes the loader clear tables with DELETE FROM under
+// session_replication_role = replica instead of TRUNCATE ... CASCADE.
+//
+// For the small, mostly-empty tables typical of fixtures this avoids the
+// relfilenode churn and ACCESS EXCLUSIVE locks of TRUNCATE and can be
+// noticeably faster. It requires the connection role to be allowed to set
+// session_replication_role (superuser or a role with bypassrls) and is meant
+// for ephemeral test databases. Sequences are not reset here — fixtures use
+// explicit ids and fixSequences realigns sequences after load.
+func WithDeleteReset() Option {
+	return func(l *LoaderPostgres) {
+		l.resetWithDelete = true
+	}
+}
+
+func New(db *sql.DB, location string, debug bool, opts ...Option) *LoaderPostgres {
+	l := &LoaderPostgres{
 		db:       db,
 		location: location,
 		debug:    debug,
 	}
+	for _, opt := range opts {
+		opt(l)
+	}
+
+	return l
 }
 
 func (f *LoaderPostgres) Load(names []string) error {
@@ -250,6 +274,10 @@ func (f *LoaderPostgres) truncateTables(tx *sql.Tx, tables ...loadedTable) error
 		set[tableName] = struct{}{}
 	}
 
+	if f.resetWithDelete {
+		return f.deleteTables(tx, tablesToTruncate)
+	}
+
 	query := fmt.Sprintf("TRUNCATE TABLE %s CASCADE", strings.Join(tablesToTruncate, ","))
 	if f.debug {
 		fmt.Println("Issuing SQL:", query)
@@ -260,6 +288,31 @@ func (f *LoaderPostgres) truncateTables(tx *sql.Tx, tables ...loadedTable) error
 	}
 
 	return nil
+}
+
+// deleteTables clears the given tables with DELETE FROM instead of TRUNCATE.
+// session_replication_role = replica (scoped to the transaction) disables FK
+// triggers so tables can be cleared in any order without CASCADE; the role is
+// then restored so the subsequent inserts still enforce foreign keys.
+func (f *LoaderPostgres) deleteTables(tx *sql.Tx, tables []string) error {
+	if _, err := tx.Exec("SET LOCAL session_replication_role = replica"); err != nil {
+		return err
+	}
+
+	for _, table := range tables {
+		//nolint:gosec // Table names come from fixture definitions, not user input.
+		query := fmt.Sprintf("DELETE FROM %s", table)
+		if f.debug {
+			fmt.Println("Issuing SQL:", query)
+		}
+		if _, err := tx.Exec(query); err != nil {
+			return err
+		}
+	}
+
+	_, err := tx.Exec("SET LOCAL session_replication_role = DEFAULT")
+
+	return err
 }
 
 func (f *LoaderPostgres) loadTable(ctx *loadContext, tx *sql.Tx, t tableName, rows table) error {

--- a/fixtures/postgres/postgres_test.go
+++ b/fixtures/postgres/postgres_test.go
@@ -165,6 +165,76 @@ func TestLoadTablesShouldResolveRefs(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestLoadTablesWithDeleteResetShouldUseDelete(t *testing.T) {
+	yml, err := os.ReadFile("../testdata/sql_refs.yaml")
+	require.NoError(t, err)
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := loadContext{
+		refsDefinition: make(map[string]row),
+		refsInserted:   make(map[string]row),
+	}
+
+	l := New(db, "", true, WithDeleteReset())
+
+	err = l.loadYml(yml, &ctx)
+	require.NoError(t, err)
+
+	mock.ExpectBegin()
+
+	mock.ExpectExec("^SET LOCAL session_replication_role = replica$").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`^DELETE FROM "public"\."table1"$`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`^DELETE FROM "public"\."table2"$`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec(`^DELETE FROM "public"\."table3"$`).
+		WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectExec("^SET LOCAL session_replication_role = DEFAULT$").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	q := `^INSERT INTO "public"."table1" AS row \("f1", "f2"\) VALUES ` +
+		`\('value1', 'value2'\) ` +
+		`RETURNING row_to_json\(row\)$`
+	mock.ExpectQuery(q).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"json"}).
+				AddRow("{\"f1\":\"value1\",\"f2\":\"value2\"}"),
+		)
+
+	q = `^INSERT INTO "public"."table2" AS row \("f1", "f2"\) VALUES ` +
+		`\('value2', 'value1'\) ` +
+		`RETURNING row_to_json\(row\)$`
+	mock.ExpectQuery(q).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"json"}).
+				AddRow("{\"f1\":\"value2\",\"f2\":\"value1\"}"),
+		)
+
+	q = `^INSERT INTO "public"."table3" AS row \("f1", "f2"\) VALUES ` +
+		`\('value1', 'value2'\) ` +
+		`RETURNING row_to_json\(row\)$`
+	mock.ExpectQuery(q).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"json"}).
+				AddRow("{\"f1\":\"value1\",\"f2\":\"value2\"}"),
+		)
+
+	mock.ExpectExec("^DO").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectCommit()
+
+	err = l.loadTables(&ctx)
+	require.NoError(t, err)
+
+	err = mock.ExpectationsWereMet()
+	require.NoError(t, err)
+}
+
 func TestLoadTablesShouldExtendRows(t *testing.T) {
 	yml, err := os.ReadFile("../testdata/sql_extend.yaml")
 	require.NoError(t, err)


### PR DESCRIPTION
## What

Adds an opt-in `WithDeleteReset()` option to the Postgres fixtures loader that clears tables with `DELETE FROM` (under `session_replication_role = replica`) instead of `TRUNCATE ... CASCADE`.

## Why

`TRUNCATE ... CASCADE` recreates the relfilenode and takes an `ACCESS EXCLUSIVE` lock on every referenced table on **each** fixture load. For the small, mostly-empty tables typical of test fixtures this is a large fixed cost that dominates per-case time.

`DELETE FROM` on such tables avoids the relfilenode churn and heavy locking. `session_replication_role = replica` (scoped to the load transaction) disables FK triggers so tables can be cleared in any order without `CASCADE`; the role is then restored so the subsequent inserts still enforce foreign keys.

Measured on a real service test suite (~85 fixture cases, ephemeral Postgres with `fsync=off`): per-suite runtime dropped ~47% locally and ~22% in CI, with the fixture reset going from the dominant cost to negligible.

## Notes

- **Opt-in, backward compatible.** `New(db, location, debug)` keeps working; enable via `New(db, location, debug, postgres.WithDeleteReset())`. Default stays `TRUNCATE ... CASCADE`.
- **Requirements.** The connection role must be allowed to set `session_replication_role` (superuser or `bypassrls`). Intended for ephemeral test databases. Sequences are not reset by `DELETE` — fixtures use explicit ids and `fixSequences` already realigns sequences after load.
- Adds a unit test for the DELETE path; existing behaviour/tests unchanged.
