### PR TITLE
feat(allure): add support for arbitrary default Allure labels

### DIFF
--- a/examples/allure-report/report_usage_test.go
+++ b/examples/allure-report/report_usage_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/lamoda/gonkey/models"
 	"github.com/lamoda/gonkey/runner"
 )
 
@@ -122,5 +123,33 @@ func TestAPIWithAllure2_TestITLabels(t *testing.T) {
 		TestsDir:        "without_labels_test.yaml",
 		AllurePackage:   "api",
 		AllureTestClass: "UsersHandler",
+	})
+}
+
+func TestAPIWithAllure2_CustomDefaultLabels(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Path == "/api/users/123" && r.Method == "GET" {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"id": 123, "username": "testuser", "email": "test@example.com"}`))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	os.Setenv("GONKEY_ALLURE_DIR", "./allure-results-custom-labels")
+	os.Setenv("GONKEY_ALLURE_FORMAT", "v2")
+
+	runner.RunWithTesting(t, &runner.RunWithTestingParams{
+		Server:          srv,
+		TestsDir:        "without_labels_test.yaml",
+		AllurePackage:   "api",
+		AllureTestClass: "UsersHandler",
+		AllureDefaultLabels: []models.AllureLabel{
+			{Name: "layer", Value: "Integration"},
+			{Name: "package", Value: "cron"},
+		},
 	})
 }

--- a/output/allure_report/allure2_output.go
+++ b/output/allure_report/allure2_output.go
@@ -17,9 +17,8 @@ import (
 
 // Allure2Output generates Allure 2 JSON format reports
 type Allure2Output struct {
-	reportLocation   string
-	defaultPackage   string
-	defaultTestClass string
+	reportLocation string
+	defaultLabels  []models.AllureLabel
 }
 
 // NewAllure2Output creates a new Allure 2 output handler
@@ -32,10 +31,22 @@ func NewAllure2Output(reportLocation string) *Allure2Output {
 	}
 }
 
+// WithDefaultAllureLabels sets default labels for tests without matching labels.
+func (o *Allure2Output) WithDefaultAllureLabels(labels []models.AllureLabel) *Allure2Output {
+	o.defaultLabels = labels
+	return o
+}
+
 // WithDefaultLabels sets default package and testClass labels
 func (o *Allure2Output) WithDefaultLabels(packageLabel, testClassLabel string) *Allure2Output {
-	o.defaultPackage = packageLabel
-	o.defaultTestClass = testClassLabel
+	labels := make([]models.AllureLabel, 0, 2)
+	if packageLabel != "" {
+		labels = append(labels, models.AllureLabel{Name: "package", Value: packageLabel})
+	}
+	if testClassLabel != "" {
+		labels = append(labels, models.AllureLabel{Name: "testClass", Value: testClassLabel})
+	}
+	o.defaultLabels = labels
 	return o
 }
 
@@ -53,18 +64,12 @@ func (o *Allure2Output) Process(t models.TestInterface, result *models.Result) e
 		allureResult.WithStatusDetails(err.Error(), "")
 	}
 
-	hasPackageLabel := false
-	hasTestClassLabel := false
+	presentLabels := make(map[string]bool)
 
 	if metadata := t.GetAllureMetadata(); metadata != nil {
 		for _, label := range metadata.Labels {
 			allureResult.AddLabel(label.Name, label.Value)
-			if label.Name == "package" {
-				hasPackageLabel = true
-			}
-			if label.Name == "testClass" {
-				hasTestClassLabel = true
-			}
+			presentLabels[label.Name] = true
 		}
 
 		for _, link := range metadata.Links {
@@ -76,11 +81,8 @@ func (o *Allure2Output) Process(t models.TestInterface, result *models.Result) e
 		}
 	}
 
-	if !hasPackageLabel && o.defaultPackage != "" {
-		allureResult.AddLabel("package", o.defaultPackage)
-	}
-	if !hasTestClassLabel && o.defaultTestClass != "" {
-		allureResult.AddLabel("testClass", o.defaultTestClass)
+	for _, label := range defaultLabelsToApply(presentLabels, o.defaultLabels) {
+		allureResult.AddLabel(label.Name, label.Value)
 	}
 
 	allureResult.AddLabel(allure2.LabelFramework, "gonkey")
@@ -443,6 +445,20 @@ func categorizeErrors(errs []error) map[models.ErrorCategory]ErrorsByIdentifier 
 }
 
 func (o *Allure2Output) Finalize() {
+}
+
+func defaultLabelsToApply(presentLabels map[string]bool, defaults []models.AllureLabel) []models.AllureLabel {
+	applied := make([]models.AllureLabel, 0, len(defaults))
+	for _, label := range defaults {
+		if label.Name == "" || label.Value == "" {
+			continue
+		}
+		if presentLabels[label.Name] {
+			continue
+		}
+		applied = append(applied, label)
+	}
+	return applied
 }
 
 func groupErrorsByEndpoint(errs []error) map[string][]error {

--- a/output/allure_report/allure2_output_test.go
+++ b/output/allure_report/allure2_output_test.go
@@ -10,6 +10,64 @@ import (
 	"github.com/lamoda/gonkey/models"
 )
 
+func TestDefaultLabelsToApply(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		presentLabels map[string]bool
+		defaults      []models.AllureLabel
+		want          []models.AllureLabel
+	}{
+		{
+			name:          "apply all defaults when test has no labels",
+			presentLabels: map[string]bool{},
+			defaults: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "team", Value: "Orders shipment"},
+			},
+			want: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "team", Value: "Orders shipment"},
+			},
+		},
+		{
+			name: "skip defaults overridden by test labels",
+			presentLabels: map[string]bool{
+				"layer": true,
+			},
+			defaults: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "team", Value: "Orders shipment"},
+			},
+			want: []models.AllureLabel{
+				{Name: "team", Value: "Orders shipment"},
+			},
+		},
+		{
+			name:          "skip empty defaults",
+			presentLabels: map[string]bool{},
+			defaults: []models.AllureLabel{
+				{Name: "layer", Value: ""},
+				{Name: "", Value: "Integration"},
+				{Name: "team", Value: "Orders shipment"},
+			},
+			want: []models.AllureLabel{
+				{Name: "team", Value: "Orders shipment"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := defaultLabelsToApply(tt.presentLabels, tt.defaults)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGroupErrorsByEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+
+	"github.com/lamoda/gonkey/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestDontFollowRedirects(t *testing.T) {
@@ -21,4 +24,70 @@ func testServerRedirect() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/redirect-url", http.StatusFound)
 	}))
+}
+
+func TestBuildAllureDefaultLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		params *RunWithTestingParams
+		want   []models.AllureLabel
+	}{
+		{
+			name: "legacy fields override custom labels",
+			params: &RunWithTestingParams{
+				AllureDefaultLabels: []models.AllureLabel{
+					{Name: "layer", Value: "Integration"},
+					{Name: "package", Value: "cron"},
+				},
+				AllurePackage:   "api",
+				AllureTestClass: "UsersHandler",
+			},
+			want: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "package", Value: "api"},
+				{Name: "testClass", Value: "UsersHandler"},
+			},
+		},
+		{
+			name: "empty legacy fields do not overwrite custom package/testClass",
+			params: &RunWithTestingParams{
+				AllureDefaultLabels: []models.AllureLabel{
+					{Name: "layer", Value: "Integration"},
+					{Name: "package", Value: "cron"},
+					{Name: "testClass", Value: "CronHandler"},
+				},
+			},
+			want: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "package", Value: "cron"},
+				{Name: "testClass", Value: "CronHandler"},
+			},
+		},
+		{
+			name: "empty name or value labels are dropped",
+			params: &RunWithTestingParams{
+				AllureDefaultLabels: []models.AllureLabel{
+					{Name: "layer", Value: "Integration"},
+					{Name: "team", Value: ""},
+					{Name: "", Value: "Orders shipment"},
+				},
+				AllurePackage:   "api",
+				AllureTestClass: "UsersHandler",
+			},
+			want: []models.AllureLabel{
+				{Name: "layer", Value: "Integration"},
+				{Name: "package", Value: "api"},
+				{Name: "testClass", Value: "UsersHandler"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, buildAllureDefaultLabels(tt.params))
+		})
+	}
 }

--- a/runner/runner_testing.go
+++ b/runner/runner_testing.go
@@ -53,6 +53,8 @@ type RunWithTestingParams struct {
 	// TestIT labels: can be overridden by test-level labels
 	AllurePackage   string
 	AllureTestClass string
+	// AllureDefaultLabels are default labels; AllurePackage/AllureTestClass override package/testClass.
+	AllureDefaultLabels []models.AllureLabel
 }
 
 func registerMocksEnvironment(m *mocks.Mocks) {
@@ -122,7 +124,7 @@ func RunWithTesting(t *testing.T, params *RunWithTestingParams) {
 			runner.AddOutput(allureOutput)
 		case "v2", "json":
 			allureOutput := allure_report.NewAllure2Output(allureDir).
-				WithDefaultLabels(params.AllurePackage, params.AllureTestClass)
+				WithDefaultAllureLabels(buildAllureDefaultLabels(params))
 			defer allureOutput.Finalize()
 			runner.AddOutput(allureOutput)
 		default:
@@ -163,6 +165,36 @@ func initRunner(
 	)
 
 	return runner
+}
+
+func buildAllureDefaultLabels(params *RunWithTestingParams) []models.AllureLabel {
+	var labels []models.AllureLabel
+	for _, label := range params.AllureDefaultLabels {
+		if label.Name == "" || label.Value == "" {
+			continue
+		}
+		labels = upsertAllureLabel(labels, label.Name, label.Value)
+	}
+	if params.AllurePackage != "" {
+		labels = upsertAllureLabel(labels, "package", params.AllurePackage)
+	}
+	if params.AllureTestClass != "" {
+		labels = upsertAllureLabel(labels, "testClass", params.AllureTestClass)
+	}
+
+	return labels
+}
+
+func upsertAllureLabel(labels []models.AllureLabel, name, value string) []models.AllureLabel {
+	for i := range labels {
+		if labels[i].Name == name {
+			labels[i].Value = value
+
+			return labels
+		}
+	}
+
+	return append(labels, models.AllureLabel{Name: name, Value: value})
 }
 
 func addCheckers(runner *Runner, params *RunWithTestingParams) {


### PR DESCRIPTION
Add WithDefaultAllureLabels and RunWithTestingParams.AllureDefaultLabels. Per-test labels take precedence; AllurePackage/AllureTestClass override package/testClass. WithDefaultLabels kept for backward compatibility.